### PR TITLE
Added support for namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - ADAPTER=Void
     - LIBRARY=Bridge
     - LIBRARY=Hierarchy
+    - LIBRARY=Namespaced
     - LIBRARY=SessionHandler
     - LIBRARY=Taggable
 

--- a/src/Namespaced/.gitignore
+++ b/src/Namespaced/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+

--- a/src/Namespaced/LICENSE
+++ b/src/Namespaced/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Aaron Scherer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/Namespaced/NamespacedCachePool.php
+++ b/src/Namespaced/NamespacedCachePool.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Namespaced;
+
+use Cache\Hierarchy\HierarchicalPoolInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Prefix all the stored items with a namespace. Also make sure you can clear all items
+ * in that namespace.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class NamespacedCachePool implements CacheItemPoolInterface
+{
+    /**
+     * @type HierarchicalPoolInterface|CacheItemPoolInterface
+     */
+    private $cachePool;
+
+    /**
+     * @type string
+     */
+    private $namespace;
+
+    /**
+     * @param HierarchicalPoolInterface $cachePool
+     * @param string                    $namespace
+     */
+    public function __construct(HierarchicalPoolInterface $cachePool, $namespace)
+    {
+        $this->cachePool = $cachePool;
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * Add namespace prefix on the key.
+     *
+     * @param array $keys
+     */
+    private function prefixValue(&$key)
+    {
+        // |namespace|key
+        $key = HierarchicalPoolInterface::HIERARCHY_SEPARATOR.$this->namespace.HierarchicalPoolInterface::HIERARCHY_SEPARATOR.$key;
+    }
+
+    /**
+     * @param array $keys
+     */
+    private function prefixValues(array &$keys)
+    {
+        foreach ($keys as &$key) {
+            $this->prefixValue($key);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->getItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = [])
+    {
+        $this->prefixValues($keys);
+
+        return $this->cachePool->getItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->hasItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return $this->cachePool->deleteItem(HierarchicalPoolInterface::HIERARCHY_SEPARATOR.$this->namespace);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->deleteItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        $this->prefixValues($keys);
+
+        return $this->cachePool->deleteItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        return $this->cachePool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        return $this->cachePool->saveDeferred($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return $this->cachePool->commit();
+    }
+}

--- a/src/Namespaced/README.md
+++ b/src/Namespaced/README.md
@@ -1,0 +1,30 @@
+# Namespaced PSR-6 cache pool 
+[![Gitter](https://badges.gitter.im/php-cache/cache.svg)](https://gitter.im/php-cache/cache?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Latest Stable Version](https://poser.pugx.org/cache/namespaced-cache/v/stable)](https://packagist.org/packages/cache/namespaced-cache)
+[![Total Downloads](https://poser.pugx.org/cache/namespaced-cache/downloads)](https://packagist.org/packages/cache/namespaced-cache)
+[![Monthly Downloads](https://poser.pugx.org/cache/namespaced-cache/d/monthly.png)](https://packagist.org/packages/cache/namespaced-cache)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
+
+This is a decorator for a PSR56 hierarchical cache. It will allow you do use namespaces.  
+
+It is a part of the PHP Cache organisation. To read about features like tagging and hierarchy support please read 
+the shared documentation at [www.php-cache.com](http://www.php-cache.com). 
+
+### Install
+
+```bash
+composer require cache/namespaced-cache
+```
+ 
+### Use
+
+```php
+$hierarchyPool = new RedisCachePool($client);
+$namespacedPool = new NamespacedCachePool($hierarchyPool, 'acme');
+```
+
+### Contribute
+
+Contributions are very welcome! Send a pull request to the [main repository](https://github.com/php-cache/cache) or 
+report any issues you find on the [issue tracker](http://issues.php-cache.com).
+

--- a/src/Namespaced/Tests/HelperInterface.php
+++ b/src/Namespaced/Tests/HelperInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Namespaced\Tests;
+
+use Cache\Hierarchy\HierarchicalPoolInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+interface HelperInterface extends HierarchicalPoolInterface, CacheItemPoolInterface
+{
+}

--- a/src/Namespaced/Tests/NamespacedCachePoolTest.php
+++ b/src/Namespaced/Tests/NamespacedCachePoolTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Namespaced\Tests;
+
+use Cache\Namespaced\NamespacedCachePool;
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * We should not use constants on interfaces in the tests. Tests should break if the constant is changed.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class NamespacedCachePoolTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getHierarchyCacheStub()
+    {
+        return $this->getMock(
+            HelperInterface::class,
+            ['getItem', 'getItems', 'hasItem', 'clear', 'deleteItem', 'deleteItems', 'save', 'saveDeferred', 'commit']
+        );
+    }
+
+    public function testGetItem()
+    {
+        $namespace   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('getItem')->with('|'.$namespace.'|'.$key)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->getItem($key));
+    }
+
+    public function testGetItems()
+    {
+        $namespace   = 'ns';
+        $key0        = 'key0';
+        $key1        = 'key1';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('getItems')->with(['|'.$namespace.'|'.$key0, '|'.$namespace.'|'.$key1])->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->getItems([$key0, $key1]));
+    }
+
+    public function testHasItem()
+    {
+        $namespace   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('hasItem')->with('|'.$namespace.'|'.$key)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->hasItem($key));
+    }
+
+    public function testClear()
+    {
+        $namespace   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('deleteItem')->with('|'.$namespace)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->clear($key));
+    }
+
+    public function testDeleteItem()
+    {
+        $namespace   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('deleteItem')->with('|'.$namespace.'|'.$key)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->deleteItem($key));
+    }
+
+    public function testDeleteItems()
+    {
+        $namespace   = 'ns';
+        $key0        = 'key0';
+        $key1        = 'key1';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('deleteItems')->with(['|'.$namespace.'|'.$key0, '|'.$namespace.'|'.$key1])->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->deleteItems([$key0, $key1]));
+    }
+
+    public function testSave()
+    {
+        $item        = $this->getMock(CacheItemInterface::class);
+        $namespace   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('save')->with($item)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->save($item));
+    }
+
+    public function testSaveDeffered()
+    {
+        $item        = $this->getMock(CacheItemInterface::class);
+        $namespace   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('saveDeferred')->with($item)->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->saveDeferred($item));
+    }
+
+    public function testCommit()
+    {
+        $namespace   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('commit')->willReturn($returnValue);
+
+        $pool = new NamespacedCachePool($stub, $namespace);
+        $this->assertEquals($returnValue, $pool->commit());
+    }
+}

--- a/src/Namespaced/composer.json
+++ b/src/Namespaced/composer.json
@@ -1,0 +1,37 @@
+{
+    "name":              "cache/namespaced-cache",
+    "description":       "A decorator that makes your cache support namespaces",
+    "type":              "library",
+    "license":           "MIT",
+    "minimum-stability": "stable",
+    "keywords":          [
+        "cache",
+        "psr-6",
+        "namespace"
+    ],
+    "homepage":          "http://www.php-cache.com/en/latest/",
+    "authors":           [
+        {
+            "name":     "Tobias Nyholm",
+            "email":    "tobias.nyholm@gmail.com",
+            "homepage": "https://github.com/nyholm"
+        }
+    ],
+    "require":           {
+        "php":                      "^5.5|^7.0",
+        "psr/cache":                "^1.0",
+        "cache/hierarchical-cache": "^0.2"
+    },
+    "require-dev":       {
+        "phpunit/phpunit":         "^4.0|^5.1",
+        "cache/integration-tests": "^0.9"
+    },
+    "autoload":          {
+        "psr-4":                 {
+            "Cache\\Namespaced\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    }
+}

--- a/src/Namespaced/phpunit.xml.dist
+++ b/src/Namespaced/phpunit.xml.dist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  syntaxCheck="false"
+  bootstrap="vendor/autoload.php"
+  >
+  <testsuites>
+    <testsuite name="Main Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <logging>
+    <log type="coverage-text" target="php://stdout"/>
+    <log type="coverage-html" target="./coverageReport"/>
+  </logging>
+
+  <groups>
+    <exclude>
+      <group>benchmark</group>
+    </exclude>
+  </groups>
+
+  <filter>
+    <whitelist>
+      <directory>./</directory>
+      <exclude>
+        <directory>./Tests</directory>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
This is a decorator that lets you use namespaces. It is inspired by [eZPublish's decorator](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php). 

This could be used as an alternative to tagging and will make sure you do not have any key collisions. 

Ping @andrerom