### PR TITLE
Removed all extension dependencies

### DIFF
--- a/src/Adapter/Apc/composer.json
+++ b/src/Adapter/Apc/composer.json
@@ -24,10 +24,12 @@
     ],
     "require":           {
         "php":                  "^5.5|^7.0",
-        "ext-apc":              "*",
         "psr/cache":            "^1.0",
         "cache/adapter-common": "^0.3",
         "cache/taggable-cache": "^0.4"
+    },
+    "suggest":          {
+        "ext-apc": "The extension required to use this pool."
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",

--- a/src/Adapter/Apcu/composer.json
+++ b/src/Adapter/Apcu/composer.json
@@ -24,7 +24,6 @@
     ],
     "require":           {
         "php":                  "^5.5|^7.0",
-        "ext-apcu":             "*",
         "psr/cache":            "^1.0",
         "cache/adapter-common": "^0.3",
         "cache/taggable-cache": "^0.4"
@@ -32,6 +31,9 @@
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
         "cache/integration-tests": "^0.9"
+    },
+    "suggest":          {
+        "ext-apcu": "The extension required to use this pool."
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -25,7 +25,6 @@
     ],
     "require":           {
         "php":                  "^5.5",
-        "ext-memcache":         "*",
         "psr/cache":            "^1.0",
         "cache/adapter-common": "^0.3",
         "cache/taggable-cache": "^0.4"
@@ -33,6 +32,9 @@
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
         "cache/integration-tests": "^0.9"
+    },
+    "suggest":          {
+        "ext-memcache": "The extension required to use this pool."
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Memcached/composer.json
+++ b/src/Adapter/Memcached/composer.json
@@ -25,7 +25,6 @@
     ],
     "require":           {
         "php":                      "^5.5|^7.0",
-        "ext-memcached":            "*",
         "psr/cache":                "^1.0",
         "cache/adapter-common":     "^0.3",
         "cache/taggable-cache":     "^0.4",
@@ -34,6 +33,9 @@
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
         "cache/integration-tests": "^0.9"
+    },
+    "suggest":          {
+        "ext-memcached": "The extension required to use this pool."
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Redis/composer.json
+++ b/src/Adapter/Redis/composer.json
@@ -26,7 +26,6 @@
     ],
     "require":           {
         "php":                      "^5.5|^7.0",
-        "ext-redis":                "*",
         "psr/cache":                "^1.0",
         "cache/adapter-common":     "^0.3",
         "cache/taggable-cache":     "^0.4",
@@ -35,6 +34,9 @@
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
         "cache/integration-tests": "^0.9"
+    },
+    "suggest":          {
+        "ext-redis": "The extension required to use this pool."
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"


### PR DESCRIPTION
Extension dependencies can be somewhat problematic. If you e.g. want to offer users a configurable choice between say Redis and Memcached, you need to include both adapters in your project. This doesn't however impose a requirement upon the server to have both ext-redis and ext-memcached. If this were just regular dependencies, that wouldn't be much of a problem, but because extensions cannot be installed through composer, platform requirements are more of a hassle.

As such, this is a PR for removing the extension requirements.