### PR TITLE
HierarchicalPoolInterface extends CacheItemPoolInterface

### DIFF
--- a/src/Hierarchy/HierarchicalPoolInterface.php
+++ b/src/Hierarchy/HierarchicalPoolInterface.php
@@ -11,7 +11,14 @@
 
 namespace Cache\Hierarchy;
 
-interface HierarchicalPoolInterface
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Let you use hierarchy if you start your tag key with the HIERARCHY_SEPARATOR.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface HierarchicalPoolInterface extends CacheItemPoolInterface
 {
     const HIERARCHY_SEPARATOR = '|';
 }

--- a/src/Namespaced/NamespacedCachePool.php
+++ b/src/Namespaced/NamespacedCachePool.php
@@ -24,7 +24,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class NamespacedCachePool implements CacheItemPoolInterface
 {
     /**
-     * @type HierarchicalPoolInterface|CacheItemPoolInterface
+     * @type HierarchicalPoolInterface
      */
     private $cachePool;
 

--- a/src/Namespaced/Tests/HelperInterface.php
+++ b/src/Namespaced/Tests/HelperInterface.php
@@ -12,8 +12,7 @@
 namespace Cache\Namespaced\Tests;
 
 use Cache\Hierarchy\HierarchicalPoolInterface;
-use Psr\Cache\CacheItemPoolInterface;
 
-interface HelperInterface extends HierarchicalPoolInterface, CacheItemPoolInterface
+interface HelperInterface extends HierarchicalPoolInterface
 {
 }


### PR DESCRIPTION
If you are writing a class and want to type hint for the HierarchicalPoolInterface you will not be able to use any Pool functions. (Since they are not type safe) 

This will fix https://github.com/php-cache/issues/issues/48