### PR TITLE
Move predis/predis to suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "require":     {
         "php":              "^5.5|^7.0",
         "psr/cache":        "^1.0",
-        "predis/predis":    "^1.0",
         "doctrine/cache":   "^1.3",
         "league/flysystem": "^1.0",
         "symfony/options-resolver": "^2.7|^3.0"
@@ -41,7 +40,8 @@
         "ext-memcached":   "Memcached extension is required to use the Memcached Adapter",
         "ext-redis":       "Redis extension is required to use the Redis adapter",
         "ext-mongodb":     "Mongodb extension required to use the Mongodb adapter",
-        "mongodb/mongodb": "Mongodb extension required to use the Mongodb adapter"
+        "mongodb/mongodb": "Mongodb extension required to use the Mongodb adapter",
+        "predis/predis":   "Required to use the Predis adapter.",
     },
     "conflict":    {
         "cache/apc-adapter":           "*",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-redis":       "Redis extension is required to use the Redis adapter",
         "ext-mongodb":     "Mongodb extension required to use the Mongodb adapter",
         "mongodb/mongodb": "Mongodb extension required to use the Mongodb adapter",
-        "predis/predis":   "Required to use the Predis adapter.",
+        "predis/predis":   "Required to use the Predis adapter."
     },
     "conflict":    {
         "cache/apc-adapter":           "*",


### PR DESCRIPTION
Due to breakage when combined with Laravel 4 and below (L4 imposes predis 0.8.7 restriction) I moved predis/predis to suggest-section of composer.json.

If my changes turn out to break Travis I'll just close the PR and go cry in the corner.