### PR TITLE
Saving an expired value should be the same as removing that value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpunit/phpunit":         "^4.0|^5.1",
         "mockery/mockery":         "^0.9",
-        "cache/integration-tests": "^0.9",
+        "cache/integration-tests": "^0.10",
         "symfony/cache":           "dev-master"
     },
     "suggest":     {

--- a/src/Adapter/Apc/composer.json
+++ b/src/Adapter/Apc/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Apcu/composer.json
+++ b/src/Adapter/Apcu/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "suggest":          {
         "ext-apcu": "The extension required to use this pool."

--- a/src/Adapter/Chain/composer.json
+++ b/src/Adapter/Chain/composer.json
@@ -35,7 +35,7 @@
         "phpunit/phpunit":         "^4.0|^5.1",
         "cache/predis-adapter":    "@stable",
         "cache/array-adapter":     "@stable",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -180,6 +180,10 @@ abstract class AbstractCachePool implements CacheItemPoolInterface, LoggerAwareI
         if ($item instanceof HasExpirationDateInterface) {
             if (null !== $expirationDate = $item->getExpirationDate()) {
                 $timeToLive = $expirationDate->getTimestamp() - time();
+
+                if ($timeToLive < 0) {
+                    return $this->deleteItem($item->getKey());
+                }
             }
         }
 

--- a/src/Adapter/Common/composer.json
+++ b/src/Adapter/Common/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "autoload":          {
         "psr-4": {

--- a/src/Adapter/Doctrine/composer.json
+++ b/src/Adapter/Doctrine/composer.json
@@ -33,7 +33,7 @@
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
         "mockery/mockery":         "^0.9",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Filesystem/composer.json
+++ b/src/Adapter/Filesystem/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "suggest":          {
         "ext-memcache": "The extension required to use this pool."

--- a/src/Adapter/Memcached/composer.json
+++ b/src/Adapter/Memcached/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "suggest":          {
         "ext-memcached": "The extension required to use this pool."

--- a/src/Adapter/MongoDB/composer.json
+++ b/src/Adapter/MongoDB/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/PHPArray/composer.json
+++ b/src/Adapter/PHPArray/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Predis/composer.json
+++ b/src/Adapter/Predis/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Adapter/Redis/composer.json
+++ b/src/Adapter/Redis/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "suggest":          {
         "ext-redis": "The extension required to use this pool."

--- a/src/Adapter/Void/composer.json
+++ b/src/Adapter/Void/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "provide":           {
         "psr/cache-implementation": "^1.0"

--- a/src/Bridge/composer.json
+++ b/src/Bridge/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit":         "^4.0|^5.1",
         "mockery/mockery":         "^0.9",
         "cache/doctrine-adapter":  "@stable",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "autoload":    {
         "psr-4":                 {

--- a/src/Hierarchy/composer.json
+++ b/src/Hierarchy/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "autoload":          {
         "psr-4":                 {

--- a/src/Namespaced/composer.json
+++ b/src/Namespaced/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0|^5.1",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "autoload":          {
         "psr-4":                 {

--- a/src/SessionHandler/composer.json
+++ b/src/SessionHandler/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit":         "^4.0|^5.1",
         "mockery/mockery":         "^0.9",
         "cache/array-adapter":     "@stable",
-        "cache/integration-tests": "^0.9"
+        "cache/integration-tests": "^0.10"
     },
     "autoload":    {
         "psr-4":                 {

--- a/src/Taggable/composer.json
+++ b/src/Taggable/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "phpunit/phpunit":         "^4.1|^5.1",
-        "cache/integration-tests": "^0.9",
+        "cache/integration-tests": "^0.10",
         "symfony/cache":           "dev-master"
     },
     "autoload":    {


### PR DESCRIPTION
@nicolas-grekas  [suggested](https://github.com/php-cache/integration-tests/pull/51) that saving an expired value should be the same as removing that value form the cache. I believe it makes sense. This PR makes sure we comply with the changes he provided in the integration tests. 