### PR TITLE
Updated method of creating new DateTime to work with the clockmock

### DIFF
--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -154,7 +154,7 @@ class CacheItem implements HasExpirationDateInterface, CacheItemInterface, Tagga
         }
 
         if (is_int($time)) {
-            $this->expirationDate = new \DateTime(sprintf('+%sseconds', $time));
+            $this->expirationDate = \DateTime::createFromFormat('U', time() + $time);
         }
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

Related to: https://github.com/php-cache/integration-tests/pull/49


With this PR we change the way we are creating a new DateTime on the Item. This will allow us to speed up the tests with the new clock mock.
