### PR TITLE
Add warning because of missing locking

### DIFF
--- a/src/SessionHandler/README.md
+++ b/src/SessionHandler/README.md
@@ -24,6 +24,8 @@ $config = ['ttl'=>3600, 'prefix'=>'foobar'];
 $sessionHandler = new Psr6SessionHandler($pool, $config);
 ```
 
+Note that this session handler does no kind of locking, so it will lose or overwrite your session data if you run scripts concurrently. You have been warned.
+
 ### Contribute
 
 Contributions are very welcome! Send a pull request to the [main repository](https://github.com/php-cache/cache) or 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This is a documentation update.

I have no idea if locking can somehow be implemented in this session handler - this warning must do it for the time being.