### PR TITLE
Fixing bridge class name in documentation

### DIFF
--- a/src/Bridge/README.md
+++ b/src/Bridge/README.md
@@ -21,7 +21,7 @@ composer require cache/psr-6-doctrine-bridge
 use DoctrineCacheBridge\DoctrineCacheBridge;
 
 // Assuming $pool is an instance of \Psr\Cache\CacheItemPoolInterface
-$cacheProvider = new DoctrineBridge($pool);
+$cacheProvider = new DoctrineCacheBridge($pool);
 
 $cacheProvider->contains($key);
 $cacheProvider->fetch($key);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | This is the documentation PR

This is a backport of https://github.com/php-cache/doctrine-bridge/pull/11