### PR TITLE
Add ability to change cache path in FilesystemCachePool

### DIFF
--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -25,8 +25,6 @@ use Psr\Cache\CacheItemInterface;
  */
 class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInterface
 {
-    const CACHE_PATH = 'cache';
-
     use TaggablePoolTrait;
 
     /**
@@ -35,12 +33,28 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
     private $filesystem;
 
     /**
-     * @param Filesystem $filesystem
+     * @type string
      */
-    public function __construct(Filesystem $filesystem)
+    private $folder;
+
+    /**
+     * @param Filesystem $filesystem
+     * @param string     $folder
+     */
+    public function __construct(Filesystem $filesystem, $folder = 'cache')
     {
+        $this->folder = $folder;
+
         $this->filesystem = $filesystem;
-        $this->filesystem->createDir(self::CACHE_PATH);
+        $this->filesystem->createDir($this->folder);
+    }
+
+    /**
+     * @param string $folder
+     */
+    public function setFolder($folder)
+    {
+        $this->folder = $folder;
     }
 
     /**
@@ -71,8 +85,8 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
      */
     protected function clearAllObjectsFromCache()
     {
-        $this->filesystem->deleteDir(self::CACHE_PATH);
-        $this->filesystem->createDir(self::CACHE_PATH);
+        $this->filesystem->deleteDir($this->folder);
+        $this->filesystem->createDir($this->folder);
 
         return true;
     }
@@ -122,7 +136,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
             throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid keys must match [a-zA-Z0-9_\.! ].', $key));
         }
 
-        return sprintf('%s/%s', self::CACHE_PATH, $key);
+        return sprintf('%s/%s', $this->folder, $key);
     }
 
     /**

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -33,6 +33,8 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
     private $filesystem;
 
     /**
+     * The folder should not begin nor end with a slash. Example: path/to/cache.
+     *
      * @type string
      */
     private $folder;

--- a/src/Adapter/Filesystem/README.md
+++ b/src/Adapter/Filesystem/README.md
@@ -31,6 +31,13 @@ $filesystem        = new Filesystem($filesystemAdapter);
 $pool = new FilesystemCachePool($filesystem);
 ```
 
+You can change the folder the cache pool will write to through the `setFolder` setter:
+
+```php
+$pool = new FilesystemCachePool($filesystem);
+$pool->setFolder('path/to/cache');
+```
+
 ### Contribute
 
 Contributions are very welcome! Send a pull request to the [main repository](https://github.com/php-cache/cache) or 

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -44,4 +44,13 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($item->isHit());
         $this->assertFalse($this->getFilesystem()->has('cache/test_ttl_null'));
     }
+
+    public function testChangeFolder()
+    {
+        $pool = $this->createCachePool();
+        $pool->setFolder('foobar');
+
+        $pool->save($pool->getItem('test_path'));
+        $this->assertTrue($this->getFilesystem()->has('foobar/test_path'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | php-cache/issues#58
| License       | MIT
| Doc PR        | 

This is as far as I can see the only way to accomplish this. The constant is accessed through `self::` and the `$filesystem` property is private so there is absolutely no way to change the folder that I'm aware of.