### PR TITLE
Allow php7 for Memcache adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
     fast_finish: true
     exclude:
         - php: 7.0
-          env: ADAPTER=Memcache
 
 services:
     - redis

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require":           {
-        "php":                  "^5.5",
+        "php":                  "^5.5 || ^7.0",
         "psr/cache":            "^1.0",
         "cache/adapter-common": "^0.3",
         "cache/taggable-cache": "^0.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| License       | MIT
| Doc PR        | Add support for php7

I was surprised to see that it's not here yet. Assuming that the main repo has [php7 support already](https://github.com/php-cache/cache/blob/master/composer.json#L24), proposing to sync the change.