### PR TITLE
Make `getTagKey` protected to comply with the Trait

### DIFF
--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -227,7 +227,7 @@ class TaggablePSR6PoolAdapter implements TaggablePoolInterface
     /**
      * {@inheritdoc}
      */
-    private function getTagKey($tag)
+    protected function getTagKey($tag)
     {
         return '__tag.'.$tag;
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

Make `getTagKey` protected to comply with the Trait
