### PR TITLE
Make sure we can start using this TaggingPSRItem without dropping all existing data.

### DIFF
--- a/src/Taggable/Changelog.md
+++ b/src/Taggable/Changelog.md
@@ -3,6 +3,11 @@
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
 
 ## UNRELEASED
+## 0.4.3
+
+### Fixed
+
+* Do not lose the data when you start using the `TaggablePSR6PoolAdapter`
 
 ## 0.4.2
 

--- a/src/Taggable/TaggablePSR6ItemAdapter.php
+++ b/src/Taggable/TaggablePSR6ItemAdapter.php
@@ -85,6 +85,9 @@ class TaggablePSR6ItemAdapter implements TaggableItemInterface
         if (is_array($rawItem) && isset($rawItem['value'])) {
             return $rawItem['value'];
         }
+
+        // This is an item stored before we used this fake cache
+        return $rawItem;
     }
 
     /**

--- a/src/Taggable/TaggablePSR6ItemAdapter.php
+++ b/src/Taggable/TaggablePSR6ItemAdapter.php
@@ -82,7 +82,8 @@ class TaggablePSR6ItemAdapter implements TaggableItemInterface
     {
         $rawItem = $this->cacheItem->get();
 
-        if (is_array($rawItem) && isset($rawItem['value'])) {
+        // If it is a cache item we created
+        if ($this->isItemCreatedHere($rawItem)) {
             return $rawItem['value'];
         }
 
@@ -181,12 +182,24 @@ class TaggablePSR6ItemAdapter implements TaggableItemInterface
             if ($this->cacheItem->isHit()) {
                 $rawItem = $this->cacheItem->get();
 
-                if (is_array($rawItem) && isset($rawItem['tags'])) {
+                if ($this->isItemCreatedHere($rawItem)) {
                     $this->tags = $rawItem['tags'];
                 }
             }
 
             $this->initialized = true;
         }
+    }
+
+    /**
+     * Verify that the raw data is a cache item created by this class.
+     *
+     * @param mixed $rawItem
+     *
+     * @return bool
+     */
+    private function isItemCreatedHere($rawItem)
+    {
+        return is_array($rawItem) && isset($rawItem['value']) && isset($rawItem['tags']) && count($rawItem) === 2;
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

When we start using `TaggablePSR6PoolAdapter::makeTaggable($pool)` we currently make all data as null. This PR will make sure that we can serve legacy data. 
 
Ping @magnusnordlander and @angelsk

### TODO

* [x] Updated Changelog.md
