### PR TITLE
Minor docblock typo in ArrayCachePool

### DIFF
--- a/src/Adapter/PHPArray/ArrayCachePool.php
+++ b/src/Adapter/PHPArray/ArrayCachePool.php
@@ -21,7 +21,7 @@ use Cache\Taggable\TaggablePoolTrait;
 use Psr\Cache\CacheItemInterface;
 
 /**
- * Array cache pool. You could set a limit of how many items you wantt to be stored to avoid memory leaks.
+ * Array cache pool. You could set a limit of how many items you want to be stored to avoid memory leaks.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | https://github.com/php-cache/array-adapter/pull/5 (Moved to main repo)

### Description
Docblock typo fix to the ArrayCachePool

