### PR TITLE
Try to make clearTags() more atomic

### DIFF
--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -351,14 +351,6 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface
         // Remove all items with the tag
         $success = $this->deleteItems($itemIds);
 
-        if ($success) {
-            // Remove the tag list
-            foreach ($tags as $tag) {
-                $this->removeList($this->getTagKey($tag));
-                $l = $this->getList($this->getTagKey($tag));
-            }
-        }
-
         return $success;
     }
 

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -134,11 +134,14 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
      */
     public function deleteItems(array $keys)
     {
+        $deleted = true;
         foreach ($keys as $key) {
-            $this->preRemoveItem($key);
+            if (!$this->deleteItem($key)) {
+                $deleted = false;
+            }
         }
 
-        return $this->cachePool->deleteItems($keys);
+        return $deleted;
     }
 
     /**
@@ -260,13 +263,6 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
 
         // Remove all items with the tag
         $success = $this->deleteItems($itemIds);
-
-        if ($success) {
-            // Remove the tag list
-            foreach ($tags as $tag) {
-                $this->removeList($this->getTagKey($tag));
-            }
-        }
 
         return $success;
     }


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | php-cache/issues#74 |
| License | MIT |
| Doc PR |  |
### Description

This is my proposed fix for php-cache/issues#74. I'm not trying to avoid any exception as i am not sure that it would help, instead i'm trying to make the clearTags() method a bit more atomic.

To avoid  tagged items in the cache that are not associated to a tag-list anymore, the deletion of the item should be as close to the deletion from the list as possible and not in to seperate steps to first remove all keys from the lists and afterwards remove all keys.
Also as the clearTags() operation is not atomic the cleared list should not be removed as in the meantime new keys might have been added to the list.
