### PR TITLE
Expect ClientInterface in PredisCachePool instead of concrete Client

### DIFF
--- a/src/Adapter/Predis/Changelog.md
+++ b/src/Adapter/Predis/Changelog.md
@@ -4,6 +4,12 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+## 0.4.2
+
+### Changed
+
+* Rely on `Predis\ClientInterface` instead of `Predis\Client` in `PredisCachePool`
+
 ## 0.4.1
 
 ### Changed

--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -17,7 +17,7 @@ use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Taggable\TaggableItemInterface;
 use Cache\Taggable\TaggablePoolInterface;
 use Cache\Taggable\TaggablePoolTrait;
-use Predis\Client;
+use Predis\ClientInterface as Client;
 use Psr\Cache\CacheItemInterface;
 
 /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

Use `Predis\ClientInteface` in `PredisCachePool` instead of concrete class. Our use case is that our test stubs for cache are `Predis\ClientInterface` instances, using `Predis\Client` must be redundant in this case (concrete class adds new methods that you need to stub as well).

Let me know if CHANGELOG needs updating in this case

