### PR TITLE
Reduce filesystem operations

### DIFF
--- a/src/Adapter/Filesystem/Changelog.md
+++ b/src/Adapter/Filesystem/Changelog.md
@@ -4,6 +4,10 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+### Changed
+
+Using `Filesystem::update` instead of `Filesystem::delete` and `Filesystem::write`.
+
 ## 0.3.1
 
 ### Added

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -66,7 +66,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
     protected function fetchObjectFromCache($key)
     {
         $empty = [false, null, []];
-        $file = $this->getFilePath($key);
+        $file  = $this->getFilePath($key);
         if (!$this->filesystem->has($file)) {
             return $empty;
         }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -130,7 +130,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
 
         try {
             return $this->filesystem->write($file, $data);
-        } catch(FileExistsException $e) {
+        } catch (FileExistsException $e) {
             // To handle issues when/if race conditions occurs, we try to update here.
             return $this->filesystem->update($file, $data);
         }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -131,7 +131,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
         try {
             return $this->filesystem->write($file, $data);
         } catch(FileExistsException $e) {
-            // To handle issues when if race conditions occurs, we try to update here.
+            // To handle issues when/if race conditions occurs, we try to update here.
             return $this->filesystem->update($file, $data);
         }
     }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -108,21 +108,26 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
      */
     protected function storeItemInCache(CacheItemInterface $item, $ttl)
     {
-        $file = $this->getFilePath($item->getKey());
-        if ($this->filesystem->has($file)) {
-            $this->filesystem->delete($file);
-        }
-
         $tags = [];
         if ($item instanceof TaggableItemInterface) {
             $tags = $item->getTags();
         }
 
-        return $this->filesystem->write($file, serialize([
-            ($ttl === null ? null : time() + $ttl),
-            $item->get(),
-            $tags,
-        ]));
+        $data = serialize(
+            [
+                ($ttl === null ? null : time() + $ttl),
+                $item->get(),
+                $tags,
+            ]
+        );
+
+        $file = $this->getFilePath($item->getKey());
+        if ($this->filesystem->has($file)) {
+            // Update file if it exists
+            return $this->filesystem->update($file, $data);
+        }
+
+        return $this->filesystem->write($file, $data);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/php-cache/issues/issues/76
| License       | MIT
| Doc PR        | n/a

### Description
If we working on a remote filesystem then all operations are expensive. We should use `update` instead of `delete` and `write`.

