### PR TITLE
Swapped order of conditions in skipIfCli

### DIFF
--- a/src/Adapter/Apc/ApcCachePool.php
+++ b/src/Adapter/Apc/ApcCachePool.php
@@ -88,6 +88,6 @@ class ApcCachePool extends AbstractCachePool
      */
     private function skipIfCli()
     {
-        return php_sapi_name() === 'cli' && $this->skipOnCli;
+        return $this->skipOnCli && php_sapi_name() === 'cli';
     }
 }

--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -88,6 +88,6 @@ class ApcuCachePool extends AbstractCachePool
      */
     private function skipIfCli()
     {
-        return php_sapi_name() === 'cli' && $this->skipOnCli;
+        return $this->skipOnCli && php_sapi_name() === 'cli';
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ![Travis CI](https://travis-ci.org/SpazzMarticus/cache.svg?branch=master)
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description
Swapped order of conditions so `php_sapi_name()` is only called when necessary, which results in a minimal performace boost.

