### PR TITLE
Added prefixed cache

### DIFF
--- a/src/Prefixed/.github/PULL_REQUEST_TEMPLATE.md
+++ b/src/Prefixed/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+This is a READ ONLY repository. 
+
+Please make your pull request to https://github.com/php-cache/cache
+
+Thank you for contributing. 

--- a/src/Prefixed/.gitignore
+++ b/src/Prefixed/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+composer.lock
+

--- a/src/Prefixed/Changelog.md
+++ b/src/Prefixed/Changelog.md
@@ -1,0 +1,7 @@
+# Change Log
+
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+
+## UNRELEASED
+
+

--- a/src/Prefixed/LICENSE
+++ b/src/Prefixed/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Aaron Scherer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/src/Prefixed/PrefixedCachePool.php
+++ b/src/Prefixed/PrefixedCachePool.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Prefixed;
+
+use Cache\Hierarchy\HierarchicalPoolInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Prefix all cache items with a string.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PrefixedCachePool implements CacheItemPoolInterface
+{
+    /**
+     * @type HierarchicalPoolInterface
+     */
+    private $cachePool;
+
+    /**
+     * @type string
+     */
+    private $prefix;
+
+    /**
+     *
+     * @param CacheItemPoolInterface $cachePool
+     * @param string $prefix
+     */
+    public function __construct(CacheItemPoolInterface $cachePool, $prefix)
+    {
+        $this->cachePool = $cachePool;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Add namespace prefix on the key.
+     *
+     * @param array $keys
+     */
+    private function prefixValue(&$key)
+    {
+        $key = $this->prefix.$key;
+    }
+
+    /**
+     * @param array $keys
+     */
+    private function prefixValues(array &$keys)
+    {
+        foreach ($keys as &$key) {
+            $this->prefixValue($key);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->getItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = [])
+    {
+        $this->prefixValues($keys);
+
+        return $this->cachePool->getItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->hasItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return $this->cachePool->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        $this->prefixValue($key);
+
+        return $this->cachePool->deleteItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        $this->prefixValues($keys);
+
+        return $this->cachePool->deleteItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        return $this->cachePool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        return $this->cachePool->saveDeferred($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return $this->cachePool->commit();
+    }
+}

--- a/src/Prefixed/README.md
+++ b/src/Prefixed/README.md
@@ -1,0 +1,30 @@
+# Prefixed PSR-6 cache pool 
+[![Gitter](https://badges.gitter.im/php-cache/cache.svg)](https://gitter.im/php-cache/cache?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Latest Stable Version](https://poser.pugx.org/cache/prefixed-cache/v/stable)](https://packagist.org/packages/cache/prefixed-cache)
+[![Total Downloads](https://poser.pugx.org/cache/prefixed-cache/downloads)](https://packagist.org/packages/cache/prefixed-cache)
+[![Monthly Downloads](https://poser.pugx.org/cache/prefixed-cache/d/monthly.png)](https://packagist.org/packages/cache/prefixed-cache)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
+
+This is a decorator for a PSR-6 hierarchical cache. It will allow you do use namespaces.
+
+It is a part of the PHP Cache organisation. To read about features like tagging and hierarchy support please read 
+the shared documentation at [www.php-cache.com](http://www.php-cache.com). 
+
+### Install
+
+```bash
+composer require cache/prefixed-cache
+```
+ 
+### Use
+
+```php
+$hierarchyPool = new RedisCachePool($client);
+$prefixedPool = new PrefixedCachePool($hierarchyPool, 'acme');
+```
+
+### Contribute
+
+Contributions are very welcome! Send a pull request to the [main repository](https://github.com/php-cache/cache) or 
+report any issues you find on the [issue tracker](http://issues.php-cache.com).
+

--- a/src/Prefixed/Tests/PrefixedCachePoolTest.php
+++ b/src/Prefixed/Tests/PrefixedCachePoolTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Prefixed\Tests;
+
+use Cache\Prefixed\PrefixedCachePool;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * We should not use constants on interfaces in the tests. Tests should break if the constant is changed.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class PrefixedCachePoolTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getHierarchyCacheStub()
+    {
+        return $this->getMockBuilder(CacheItemPoolInterface::class)->setMethods(
+            ['getItem', 'getItems', 'hasItem', 'clear', 'deleteItem', 'deleteItems', 'save', 'saveDeferred', 'commit']
+        )->getMock();
+    }
+
+    public function testGetItem()
+    {
+        $prefix   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('getItem')->with($prefix.$key)->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->getItem($key));
+    }
+
+    public function testGetItems()
+    {
+        $prefix   = 'ns';
+        $key0        = 'key0';
+        $key1        = 'key1';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('getItems')->with([$prefix.$key0, $prefix.$key1])->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->getItems([$key0, $key1]));
+    }
+
+    public function testHasItem()
+    {
+        $prefix   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('hasItem')->with($prefix.$key)->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->hasItem($key));
+    }
+
+    public function testClear()
+    {
+        $prefix   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('clear')->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->clear($key));
+    }
+
+    public function testDeleteItem()
+    {
+        $prefix   = 'ns';
+        $key         = 'key';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('deleteItem')->with($prefix.$key)->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->deleteItem($key));
+    }
+
+    public function testDeleteItems()
+    {
+        $prefix   = 'ns';
+        $key0        = 'key0';
+        $key1        = 'key1';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('deleteItems')->with([$prefix.$key0, $prefix.$key1])->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->deleteItems([$key0, $key1]));
+    }
+
+    public function testSave()
+    {
+        $item        = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $prefix   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('save')->with($item)->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->save($item));
+    }
+
+    public function testSaveDeffered()
+    {
+        $item        = $this->getMockBuilder(CacheItemInterface::class)->getMock();
+        $prefix   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('saveDeferred')->with($item)->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->saveDeferred($item));
+    }
+
+    public function testCommit()
+    {
+        $prefix   = 'ns';
+        $returnValue = true;
+
+        $stub = $this->getHierarchyCacheStub();
+        $stub->expects($this->once())->method('commit')->willReturn($returnValue);
+
+        $pool = new PrefixedCachePool($stub, $prefix);
+        $this->assertEquals($returnValue, $pool->commit());
+    }
+}

--- a/src/Prefixed/composer.json
+++ b/src/Prefixed/composer.json
@@ -1,0 +1,36 @@
+{
+    "name":              "cache/prefixed-cache",
+    "description":       "A decorator that makes your cache support prefix",
+    "type":              "library",
+    "license":           "MIT",
+    "minimum-stability": "stable",
+    "keywords":          [
+        "cache",
+        "psr-6",
+        "prefix"
+    ],
+    "homepage":          "http://www.php-cache.com/en/latest/",
+    "authors":           [
+        {
+            "name":     "Tobias Nyholm",
+            "email":    "tobias.nyholm@gmail.com",
+            "homepage": "https://github.com/nyholm"
+        }
+    ],
+    "require":           {
+        "php":                      "^5.5 || ^7.0",
+        "psr/cache":                "^1.0",
+        "cache/hierarchical-cache": "^0.3"
+    },
+    "require-dev":       {
+        "phpunit/phpunit":         "^4.0 || ^5.1"
+    },
+    "autoload":          {
+        "psr-4":                 {
+            "Cache\\Prefixed\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    }
+}

--- a/src/Prefixed/phpunit.xml.dist
+++ b/src/Prefixed/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  syntaxCheck="false"
+  bootstrap="vendor/autoload.php"
+  >
+  <testsuites>
+    <testsuite name="Main Test Suite">
+      <directory>./Tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <groups>
+    <exclude>
+      <group>benchmark</group>
+    </exclude>
+  </groups>
+
+  <filter>
+    <whitelist>
+      <directory>./</directory>
+      <exclude>
+        <directory>./Tests</directory>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | 

### Description

Added a PrefixCacheItemPool. This will support any PSR-6 caches. It differs from the Namespaced cache pool because it will clear all the cache. 

```php
$pool = new RedisCachePool($client);
$item = $pool->getItem('one')->set('bar');
$pool->save($item);

// Decorate it with a NamesapcedPool
$namespacedPool = new NamespacedCachePool($pool, 'acme');
$prefixedPool = new PrefixedCachePool($pool, 'acme');

$item = $namespacedPool->getItem('two')->set('bar');
$namespacedPool->save($item);

$item = $prefixedPool->getItem('three')->set('bar');
$prefixedPool->save($item);

$namespacedPool->hasItem('two'); // True
$prefixedPool->hasItem('three'); // True

$pool->hasItem('one'); // True
$pool->hasItem('two'); // False
$pool->hasItem('three'); // False
$pool->hasItem('acmethree'); // True

$namespacedPool->clear();
$pool->hasItem('one'); // True

$prefixedPool->clear();
$pool->hasItem('one'); // False
```


### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md

Ping @naderman