### PR TITLE
Fixed issue where Memcached expects an absolute TTL timestamp when va…

### DIFF
--- a/src/Adapter/Memcached/MemcachedCachePool.php
+++ b/src/Adapter/Memcached/MemcachedCachePool.php
@@ -85,6 +85,10 @@ class MemcachedCachePool extends AbstractCachePool implements HierarchicalPoolIn
             $ttl = 0;
         } elseif ($ttl < 0) {
             return false;
+        } elseif ($ttl > 86400 * 30) {
+            // Any time higher than 30 days is interpreted as a unix timestamp date.
+            // https://github.com/memcached/memcached/wiki/Programming#expiration
+            $ttl = time() + $ttl;
         }
 
         $key = $this->getHierarchyKey($item->getKey());

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Cache\Adapter\Memcached\Tests;
+
+
+use Cache\Adapter\Common\CacheItem;
+use Cache\Adapter\Memcached\MemcachedCachePool;
+
+class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures that TTL larger than 30 days are sent as absolute timestamps
+     * https://github.com/memcached/memcached/wiki/Programming#expiration
+     */
+    public function testTimeToLiveMoreThan30days()
+    {
+        /** @var \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
+        $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
+        $cache->expects($this->once())->method("set")->with(
+            $this->equalTo("a"),
+            $this->anything(),
+            // Test that the TTL timestamp is absolute (greaterThanOrEqual to account for small timing)
+            $this->greaterThanOrEqual(time() + (86400 * 365))
+        )->willReturn(true);
+
+        $pool = new MemcachedCachePool($cache);
+
+        $cache_item = new CacheItem("a", false, "1");
+        
+        // Input relative expiration time of 1 year
+        $cache_item->expiresAfter(86400 * 365);
+        $pool->save($cache_item);
+    }
+
+    /**
+     * Ensures that TTL less than 30 days are still sent as relative timestamps
+     */
+    public function testTimeToLiveLessThan30days()
+    {
+        /** @var \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
+        $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
+        $cache->expects($this->once())->method("set")->with(
+            $this->equalTo("b"),
+            $this->anything(),
+            // Test that the TTL timestamp is relative
+            $this->equalTo(86400 * 20)
+        )->willReturn(true);
+
+        $pool = new MemcachedCachePool($cache);
+
+        $cache_item = new CacheItem("b", false, "1");
+
+        // Input relative expiration time of 20 days
+        $cache_item->expiresAfter(86400 * 20);
+        $pool->save($cache_item);
+    }
+}

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -11,55 +11,23 @@
 
 namespace Cache\Adapter\Memcached\Tests;
 
-use Cache\Adapter\Common\CacheItem;
-use Cache\Adapter\Memcached\MemcachedCachePool;
-
 class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
 {
+    use CreatePoolTrait;
+
     /**
-     * Ensures that TTL larger than 30 days are sent as absolute timestamps
+     * Ensures that items with a TTL larger than 30 days can be stored in memcached
      * https://github.com/memcached/memcached/wiki/Programming#expiration.
      */
     public function testTimeToLiveMoreThan30days()
     {
-        /** @type \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
-        $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
-        $cache->expects($this->once())->method('set')->with(
-            $this->equalTo('a'),
-            $this->anything(),
-            // Test that the TTL timestamp is absolute (greaterThanOrEqual to account for small timing)
-            $this->greaterThanOrEqual(time() + (86400 * 365))
-        )->willReturn(true);
+        $pool = $this->createCachePool();
 
-        $pool = new MemcachedCachePool($cache);
+        $item = $pool->getItem('365days');
+        $item->set('4711');
+        $item->expiresAfter(86400 * 365);
+        $pool->save($item);
 
-        $cache_item = new CacheItem('a', false, '1');
-
-        // Input relative expiration time of 1 year
-        $cache_item->expiresAfter(86400 * 365);
-        $pool->save($cache_item);
-    }
-
-    /**
-     * Ensures that TTL less than 30 days are still sent as relative timestamps.
-     */
-    public function testTimeToLiveLessThan30days()
-    {
-        /** @type \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
-        $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
-        $cache->expects($this->once())->method('set')->with(
-            $this->equalTo('b'),
-            $this->anything(),
-            // Test that the TTL timestamp is relative
-            $this->equalTo(86400 * 20)
-        )->willReturn(true);
-
-        $pool = new MemcachedCachePool($cache);
-
-        $cache_item = new CacheItem('b', false, '1');
-
-        // Input relative expiration time of 20 days
-        $cache_item->expiresAfter(86400 * 20);
-        $pool->save($cache_item);
+        $this->assertTrue($pool->getItem('365days')->isHit(), "Item is not stored correctly");
     }
 }

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -1,8 +1,15 @@
 <?php
 
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Cache\Adapter\Memcached\Tests;
-
 
 use Cache\Adapter\Common\CacheItem;
 use Cache\Adapter\Memcached\MemcachedCachePool;
@@ -11,14 +18,14 @@ class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Ensures that TTL larger than 30 days are sent as absolute timestamps
-     * https://github.com/memcached/memcached/wiki/Programming#expiration
+     * https://github.com/memcached/memcached/wiki/Programming#expiration.
      */
     public function testTimeToLiveMoreThan30days()
     {
-        /** @var \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
+        /** @type \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
         $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
-        $cache->expects($this->once())->method("set")->with(
-            $this->equalTo("a"),
+        $cache->expects($this->once())->method('set')->with(
+            $this->equalTo('a'),
             $this->anything(),
             // Test that the TTL timestamp is absolute (greaterThanOrEqual to account for small timing)
             $this->greaterThanOrEqual(time() + (86400 * 365))
@@ -26,22 +33,22 @@ class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
 
         $pool = new MemcachedCachePool($cache);
 
-        $cache_item = new CacheItem("a", false, "1");
-        
+        $cache_item = new CacheItem('a', false, '1');
+
         // Input relative expiration time of 1 year
         $cache_item->expiresAfter(86400 * 365);
         $pool->save($cache_item);
     }
 
     /**
-     * Ensures that TTL less than 30 days are still sent as relative timestamps
+     * Ensures that TTL less than 30 days are still sent as relative timestamps.
      */
     public function testTimeToLiveLessThan30days()
     {
-        /** @var \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
+        /** @type \Memcached|\PHPUnit_Framework_MockObject_MockObject $cache */
         $cache = $this->getMockBuilder(\Memcached::class)->disableOriginalConstructor()->getMock();
-        $cache->expects($this->once())->method("set")->with(
-            $this->equalTo("b"),
+        $cache->expects($this->once())->method('set')->with(
+            $this->equalTo('b'),
             $this->anything(),
             // Test that the TTL timestamp is relative
             $this->equalTo(86400 * 20)
@@ -49,7 +56,7 @@ class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
 
         $pool = new MemcachedCachePool($cache);
 
-        $cache_item = new CacheItem("b", false, "1");
+        $cache_item = new CacheItem('b', false, '1');
 
         // Input relative expiration time of 20 days
         $cache_item->expiresAfter(86400 * 20);

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -28,6 +28,6 @@ class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
         $item->expiresAfter(86400 * 365);
         $pool->save($item);
 
-        $this->assertTrue($pool->getItem('365days')->isHit(), "Item is not stored correctly");
+        $this->assertTrue($pool->getItem('365days')->isHit(), 'Item is not stored correctly');
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations?  no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description
Memcached interprets the TTL as an absolute unix timestamp if the value is more than 30 days worth of seconds. Without this fix you would write a cache item with a TTL of 1 year, memcache would interpret it as 1-1-1971 and mark the cache item as expired (but returning a TRUE on the set() method call, so this is pretty unexpected and a source of bugs.)

I'm not too familiar with this library so my fix might be in the wrong place.
Also I think a similar fix should be applied to the MemcacheCachePool (without the d).