### PR TITLE
allow `CachePool` to set `ttl` via `CacheItem` callable

### DIFF
--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -46,9 +46,13 @@ abstract class AbstractCachePool implements CacheItemPoolInterface, LoggerAwareI
     /**
      * Fetch an object from the cache implementation.
      *
+     * Some cache pools allow to return `ttl` from a stored item. A timestamp should
+     * be returned to ensure proper behavior when saving a item from a lower pool
+     * to a higher pool within a `CachePoolChain`.
+     *
      * @param string $key
      *
-     * @return array with [isHit, value, [tags]]
+     * @return array with [isHit, value, [tags], [ttl]]
      */
     abstract protected function fetchObjectFromCache($key);
 

--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -197,6 +197,10 @@ class CacheItem implements HasExpirationDateInterface, CacheItemInterface, Tagga
             $this->value    = $result[1];
             $this->tags     = isset($result[2]) ? $result[2] : [];
 
+            if (isset($result[3]) && is_int($result[3])) {
+                $this->expirationDate = new \DateTime('@'.$result[3]);
+            }
+
             $this->callable = null;
         }
     }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -77,7 +77,9 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
             return $empty;
         }
 
-        if ($data[0] !== null && time() > $data[0]) {
+        // Determine ttl from data, remove items if expired
+        $ttl = $data[0] ?: null;
+        if ($ttl !== null && time() > $ttl) {
             foreach ($data[2] as $tag) {
                 $this->removeListItem($this->getTagKey($tag), $key);
             }
@@ -86,7 +88,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
             return $empty;
         }
 
-        return [true, $data[1], $data[2]];
+        return [true, $data[1], $data[2], $ttl];
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/php-cache/issues/issues/80
| License       | MIT
| Doc PR        | ~

### Description

If using a `CachePoolChain`, having configured pool `A` and pool `B`, the scenario is possible that `A` is a miss and `B` is a hit. The `CachePoolChain` then nicely stores the item to `A`, but in this process the `ttl` is ignored. This PR allows the `CacheItem` callable to set the `expiresAt` and lets the `FilesystemCachePool` return the right value for that.

### TODO
* [ ] Add tests
* [ ] Add documentation, we should document the behavior of `ttl` because I think some pools will not be able to return the `ttl` for an existing `CacheItem`.
* [ ] Updated Changelog.md

