### PR TITLE
Remove file exists check as not required

### DIFF
--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -69,7 +69,10 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
         $file  = $this->getFilePath($key);
 
         try {
-            $data = unserialize($this->filesystem->read($file));
+            $data = @unserialize($this->filesystem->read($file));
+            if ($data === false) {
+                return $empty;
+            }
         } catch (FileNotFoundException $e) {
             return $empty;
         }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -68,9 +68,6 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
     {
         $empty = [false, null, []];
         $file  = $this->getFilePath($key);
-        if (!$this->filesystem->has($file)) {
-            return $empty;
-        }
 
         try {
             $data = unserialize($this->filesystem->read($file));

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -148,15 +148,11 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
      */
     private function getFilePath($key)
     {
-
-        //make the key a safe filename
-        $filename = str_replace('=', '_', base64_encode($key));
-
-        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $filename)) {
-            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $filename));
+        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $key)) {
+            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $key));
         }
 
-        return sprintf('%s/%s', $this->folder, $filename);
+        return sprintf('%s/%s', $this->folder, $key);
     }
 
     /**

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -159,7 +159,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
         if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $filename)) {
             throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $filename));
         }
-        
+
         return sprintf('%s/%s', $this->folder, $filename);
     }
 

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Filesystem;
 
 use Cache\Adapter\Common\AbstractCachePool;

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -152,11 +152,15 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
      */
     private function getFilePath($key)
     {
-        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $key)) {
-            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid keys must match [a-zA-Z0-9_\.! ].', $key));
-        }
 
-        return sprintf('%s/%s', $this->folder, $key);
+        //make the key a safe filename
+        $filename = str_replace('=', '_', base64_encode($key));
+
+        if (!preg_match('|^[a-zA-Z0-9_\.! ]+$|', $filename)) {
+            throw new InvalidArgumentException(sprintf('Invalid key "%s". Valid filenames must match [a-zA-Z0-9_\.! ].', $filename));
+        }
+        
+        return sprintf('%s/%s', $this->folder, $filename);
     }
 
     /**

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -10,7 +10,6 @@
  */
 
 namespace Cache\Adapter\Filesystem\Tests;
-use Cache\Adapter\Common\CacheItem;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -54,17 +53,16 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
         $pool->save($pool->getItem('test_path'));
         $this->assertTrue($this->getFilesystem()->has('foobar/test_path'));
     }
-    
+
     public function testCorruptedCacheFileHandledNicely()
     {
         $pool = $this->createCachePool();
 
         $this->getFilesystem()->write('cache/corrupt','corrupt data');
-        
+
         $item = $pool->getItem('corrupt');
         $this->assertFalse($item->isHit());
 
         $this->getFilesystem()->delete('cache/corrupt');
-
     }
 }

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Filesystem\Tests;
 
 /**

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -58,7 +58,7 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
     {
         $pool = $this->createCachePool();
 
-        $this->getFilesystem()->write('cache/corrupt','corrupt data');
+        $this->getFilesystem()->write('cache/corrupt', 'corrupt data');
 
         $item = $pool->getItem('corrupt');
         $this->assertFalse($item->isHit());

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Filesystem\Tests;
 
 /**
@@ -21,22 +20,22 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
 
     public function testCleanupOnExpire()
     {
-        $cacheKey = 'test_ttl_null';
+        $cacheKey      = 'test_ttl_null';
         $cacheFilename = $filename = str_replace('=', '_', base64_encode($cacheKey));
-        
+
         $pool = $this->createCachePool();
-        
+
         $item = $pool->getItem($cacheKey);
         $item->set('data');
         $item->expiresAt(new \DateTime('now'));
         $pool->save($item);
-        $this->assertTrue($this->getFilesystem()->has('cache/' . $cacheFilename));
-        
+        $this->assertTrue($this->getFilesystem()->has('cache/'.$cacheFilename));
+
         sleep(1);
-        
+
         $item = $pool->getItem($cacheKey);
         $this->assertFalse($item->isHit());
-        $this->assertFalse($this->getFilesystem()->has('cache/' . $cacheFilename));
+        $this->assertFalse($this->getFilesystem()->has('cache/'.$cacheFilename));
     }
 
     public function testChangeFolder()
@@ -45,6 +44,6 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
         $pool->setFolder('foobar');
 
         $pool->save($pool->getItem('test_path'));
-        $this->assertTrue($this->getFilesystem()->has('foobar/' . str_replace('=', '_', base64_encode('test_path'))));
+        $this->assertTrue($this->getFilesystem()->has('foobar/'.str_replace('=', '_', base64_encode('test_path'))));
     }
 }

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -10,6 +10,7 @@
  */
 
 namespace Cache\Adapter\Filesystem\Tests;
+use Cache\Adapter\Common\CacheItem;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -52,5 +53,18 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
 
         $pool->save($pool->getItem('test_path'));
         $this->assertTrue($this->getFilesystem()->has('foobar/test_path'));
+    }
+    
+    public function testCorruptedCacheFileHandledNicely()
+    {
+        $pool = $this->createCachePool();
+
+        $this->getFilesystem()->write('cache/corrupt','corrupt data');
+        
+        $item = $pool->getItem('corrupt');
+        $this->assertFalse($item->isHit());
+
+        $this->getFilesystem()->delete('cache/corrupt');
+
     }
 }

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -9,6 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
+
 namespace Cache\Adapter\Filesystem\Tests;
 
 /**
@@ -18,24 +19,31 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
 {
     use CreatePoolTrait;
 
-    public function testCleanupOnExpire()
+    /**
+     * @expectedException \Psr\Cache\InvalidArgumentException
+     */
+    public function testInvalidKey()
     {
-        $cacheKey      = 'test_ttl_null';
-        $cacheFilename = $filename = str_replace('=', '_', base64_encode($cacheKey));
-
         $pool = $this->createCachePool();
 
-        $item = $pool->getItem($cacheKey);
+        $pool->getItem('test%string')->get();
+    }
+
+    public function testCleanupOnExpire()
+    {
+        $pool = $this->createCachePool();
+
+        $item = $pool->getItem('test_ttl_null');
         $item->set('data');
         $item->expiresAt(new \DateTime('now'));
         $pool->save($item);
-        $this->assertTrue($this->getFilesystem()->has('cache/'.$cacheFilename));
+        $this->assertTrue($this->getFilesystem()->has('cache/test_ttl_null'));
 
         sleep(1);
 
-        $item = $pool->getItem($cacheKey);
+        $item = $pool->getItem('test_ttl_null');
         $this->assertFalse($item->isHit());
-        $this->assertFalse($this->getFilesystem()->has('cache/'.$cacheFilename));
+        $this->assertFalse($this->getFilesystem()->has('cache/test_ttl_null'));
     }
 
     public function testChangeFolder()
@@ -44,6 +52,6 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
         $pool->setFolder('foobar');
 
         $pool->save($pool->getItem('test_path'));
-        $this->assertTrue($this->getFilesystem()->has('foobar/'.str_replace('=', '_', base64_encode('test_path'))));
+        $this->assertTrue($this->getFilesystem()->has('foobar/test_path'));
     }
 }

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -19,31 +19,24 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
 {
     use CreatePoolTrait;
 
-    /**
-     * @expectedException \Psr\Cache\InvalidArgumentException
-     */
-    public function testInvalidKey()
-    {
-        $pool = $this->createCachePool();
-
-        $pool->getItem('test%string')->get();
-    }
-
     public function testCleanupOnExpire()
     {
+        $cacheKey = 'test_ttl_null';
+        $cacheFilename = $filename = str_replace('=', '_', base64_encode($cacheKey));
+        
         $pool = $this->createCachePool();
-
-        $item = $pool->getItem('test_ttl_null');
+        
+        $item = $pool->getItem($cacheKey);
         $item->set('data');
         $item->expiresAt(new \DateTime('now'));
         $pool->save($item);
-        $this->assertTrue($this->getFilesystem()->has('cache/test_ttl_null'));
-
+        $this->assertTrue($this->getFilesystem()->has('cache/' . $cacheFilename));
+        
         sleep(1);
-
-        $item = $pool->getItem('test_ttl_null');
+        
+        $item = $pool->getItem($cacheKey);
         $this->assertFalse($item->isHit());
-        $this->assertFalse($this->getFilesystem()->has('cache/test_ttl_null'));
+        $this->assertFalse($this->getFilesystem()->has('cache/' . $cacheFilename));
     }
 
     public function testChangeFolder()
@@ -52,6 +45,6 @@ class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
         $pool->setFolder('foobar');
 
         $pool->save($pool->getItem('test_path'));
-        $this->assertTrue($this->getFilesystem()->has('foobar/test_path'));
+        $this->assertTrue($this->getFilesystem()->has('foobar/' . str_replace('=', '_', base64_encode('test_path'))));
     }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        | 

### Description

In the FilesystemCachePool when reading from the file there was a check to see if the file existed, then the read. This caused a race condition. To fix I removed the file exists check and left only the read with the try catch, this removed the race condition and results in the same behaviour.

### TODO
* [ ] Add tests
* [ ] Add documentation
* [ X  ] Updated Changelog.md
