### PR TITLE
Expiration timestamp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpunit/phpunit":         "^4.0 || ^5.1",
         "mockery/mockery":         "^0.9",
         "cache/integration-tests": "^0.11",
-        "predis/predis":           "^1.0",
+        "predis/predis": "^1.0",
         "symfony/cache":           "dev-master"
     },
     "suggest":     {

--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -9,11 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Apcu;
 
 use Cache\Adapter\Common\AbstractCachePool;
-use Psr\Cache\CacheItemInterface;
+use Cache\Adapter\Common\PhpCacheItem;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -39,13 +38,17 @@ class ApcuCachePool extends AbstractCachePool
     protected function fetchObjectFromCache($key)
     {
         if ($this->skipIfCli()) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
-        $success = false;
-        $data    = apcu_fetch($key, $success);
+        $success   = false;
+        $cacheData = apcu_fetch($key, $success);
+        if (!$success) {
+            return [false, null, [], null];
+        }
+        list($data, $timestamp, $tags) = unserialize($cacheData);
 
-        return [$success, $data, []];
+        return [$success, $data, $tags, $timestamp];
     }
 
     /**
@@ -69,7 +72,7 @@ class ApcuCachePool extends AbstractCachePool
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         if ($this->skipIfCli()) {
             return false;
@@ -79,7 +82,7 @@ class ApcuCachePool extends AbstractCachePool
             return false;
         }
 
-        return apcu_store($item->getKey(), $item->get(), $ttl);
+        return apcu_store($item->getKey(), serialize([$item->get(), $item->getExpirationTimestamp(), []]), $ttl);
     }
 
     /**

--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -47,9 +47,13 @@ abstract class AbstractCachePool implements CacheItemPoolInterface, LoggerAwareI
     /**
      * Fetch an object from the cache implementation.
      *
+     * Some cache pools allow to return `ttl` from a stored item. A timestamp should
+     * be returned to ensure proper behavior when saving a item from a lower pool
+     * to a higher pool within a `CachePoolChain`.
+     *
      * @param string $key
      *
-     * @return array with [isHit, value, [tags]]
+     * @return array with [isHit, value, [tags], [ttl]]
      */
     abstract protected function fetchObjectFromCache($key);
 

--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -37,7 +37,7 @@ abstract class AbstractCachePool implements CacheItemPoolInterface, LoggerAwareI
 
     /**
      * @param PhpCacheItem $item
-     * @param int|null  $ttl  seconds from now
+     * @param int|null     $ttl  seconds from now
      *
      * @return bool true if saved
      */

--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -207,6 +207,10 @@ class CacheItem implements HasExpirationDateInterface, CacheItemInterface, Tagga
             $this->value    = $result[1];
             $this->tags     = isset($result[2]) ? $result[2] : [];
 
+            if (isset($result[3]) && is_int($result[3])) {
+                $this->expirationDate = new \DateTime('@'.$result[3]);
+            }
+
             $this->callable = null;
         }
     }

--- a/src/Adapter/Common/Changelog.md
+++ b/src/Adapter/Common/Changelog.md
@@ -4,6 +4,13 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+### Changed
+
+* First parameter to `AbstractCachePool::storeItemInCache` must be a `PhpCacheItem`. 
+* Return value from `AbstractCachePool::fetchObjectFromCache` must be a an array with 4 values. Added expiration timestamp. 
+* `HasExpirationDateInterface` is replaced by `HasExpirationTimestampInterface`
+* We do not work with `\DateTime` anymore. We work with timestamps. 
+
 ## 0.3.3
 
 ### Fixed

--- a/src/Adapter/Common/HasExpirationTimestampInterface.php
+++ b/src/Adapter/Common/HasExpirationTimestampInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Adapter\Common;
+
+/**
+ * @author Aaron Scherer <aequasi@gmail.com>
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+interface HasExpirationTimestampInterface
+{
+    /**
+     * The timestamp when the object expires.
+     *
+     * @return int|null
+     */
+    public function getExpirationTimestamp();
+}

--- a/src/Adapter/Common/PhpCacheItem.php
+++ b/src/Adapter/Common/PhpCacheItem.php
@@ -9,19 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Common;
 
+use Psr\Cache\CacheItemInterface;
+
 /**
- * @author Aaron Scherer <aequasi@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-interface HasExpirationDateInterface
+interface PhpCacheItem extends HasExpirationTimestampInterface, CacheItemInterface
 {
-    /**
-     * The date and time when the object expires.
-     *
-     * @return \DateTimeInterface|null
-     */
-    public function getExpirationDate();
 }

--- a/src/Adapter/Common/Tests/CacheItemTest.php
+++ b/src/Adapter/Common/Tests/CacheItemTest.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Common\Tests;
 
 use Cache\Adapter\Common\CacheItem;
@@ -80,46 +79,47 @@ class CacheItemTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($item->isHit());
     }
 
-    public function testGetExpirationDate()
+    public function testGetExpirationTimestamp()
     {
         $item = new CacheItem('test_key');
 
-        $this->assertNull($item->getExpirationDate());
+        $this->assertNull($item->getExpirationTimestamp());
 
-        $date = new \DateTime();
+        $timestamp = time();
 
         $ref  = new \ReflectionObject($item);
-        $prop = $ref->getProperty('expirationDate');
+        $prop = $ref->getProperty('expirationTimestamp');
         $prop->setAccessible(true);
-        $prop->setValue($item, $date);
+        $prop->setValue($item, $timestamp);
 
-        $this->assertEquals($date, $item->getExpirationDate());
+        $this->assertEquals($timestamp, $item->getExpirationTimestamp());
     }
 
     public function testExpiresAt()
     {
         $item = new CacheItem('test_key');
 
-        $this->assertNull($item->getExpirationDate());
+        $this->assertNull($item->getExpirationTimestamp());
 
-        $item->expiresAt(new \DateTime('+1 second'));
+        $time = time() + 1;
+        $item->expiresAt($time);
 
-        $this->assertEquals(new \DateTime('+1 second'), $item->getExpirationDate());
+        $this->assertEquals($time, $item->getExpirationTimestamp());
     }
 
     public function testExpiresAfter()
     {
         $item = new CacheItem('test_key');
 
-        $this->assertNull($item->getExpirationDate());
+        $this->assertNull($item->getExpirationTimestamp());
 
         $item->expiresAfter(null);
         $this->assertNull($this->getExpectedException());
 
         $item->expiresAfter(new \DateInterval('PT1S'));
-        $this->assertEquals(new \DateTime('+1 second'), $item->getExpirationDate());
+        $this->assertEquals((new \DateTime('+1 second'))->getTimestamp(), $item->getExpirationTimestamp());
 
         $item->expiresAfter(1);
-        $this->assertEquals(new \DateTime('+1 second'), $item->getExpirationDate());
+        $this->assertEquals((new \DateTime('+1 second'))->getTimestamp(), $item->getExpirationTimestamp());
     }
 }

--- a/src/Adapter/Doctrine/DoctrineCachePool.php
+++ b/src/Adapter/Doctrine/DoctrineCachePool.php
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Doctrine;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Taggable\TaggableItemInterface;
 use Cache\Taggable\TaggablePoolInterface;
 use Cache\Taggable\TaggablePoolTrait;
@@ -61,7 +61,7 @@ class DoctrineCachePool extends AbstractCachePool implements TaggablePoolInterfa
     protected function fetchObjectFromCache($key)
     {
         if (false === $data = $this->cache->fetch($key)) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
         return unserialize($data);
@@ -92,7 +92,7 @@ class DoctrineCachePool extends AbstractCachePool implements TaggablePoolInterfa
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         if ($ttl === null) {
             $ttl = 0;
@@ -102,7 +102,7 @@ class DoctrineCachePool extends AbstractCachePool implements TaggablePoolInterfa
         if ($item instanceof TaggableItemInterface) {
             $tags = $item->getTags();
         }
-        $data = serialize([true, $item->get(), $tags]);
+        $data = serialize([true, $item->get(), $tags, $item->getExpirationTimestamp()]);
 
         return $this->cache->save($item->getKey(), $data, $ttl);
     }

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -78,7 +78,9 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
             return $empty;
         }
 
-        if ($data[0] !== null && time() > $data[0]) {
+        // Determine ttl from data, remove items if expired
+        $ttl = $data[0] ?: null;
+        if ($ttl !== null && time() > $ttl) {
             foreach ($data[2] as $tag) {
                 $this->removeListItem($this->getTagKey($tag), $key);
             }
@@ -87,7 +89,7 @@ class FilesystemCachePool extends AbstractCachePool implements TaggablePoolInter
             return $empty;
         }
 
-        return [true, $data[1], $data[2]];
+        return [true, $data[1], $data[2], $ttl];
     }
 
     /**

--- a/src/Adapter/Memcache/MemcacheCachePool.php
+++ b/src/Adapter/Memcache/MemcacheCachePool.php
@@ -9,12 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Memcache;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Memcache;
-use Psr\Cache\CacheItemInterface;
 
 class MemcacheCachePool extends AbstractCachePool
 {
@@ -37,7 +36,7 @@ class MemcacheCachePool extends AbstractCachePool
     protected function fetchObjectFromCache($key)
     {
         if (false === $result = unserialize($this->cache->get($key))) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
         return $result;
@@ -64,9 +63,9 @@ class MemcacheCachePool extends AbstractCachePool
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
-        $data = serialize([true, $item->get(), []]);
+        $data = serialize([true, $item->get(), [], $item->getExpirationTimestamp()]);
 
         return $this->cache->set($item->getKey(), $data, 0, $ttl ?: 0);
     }

--- a/src/Adapter/Memcached/MemcachedCachePool.php
+++ b/src/Adapter/Memcached/MemcachedCachePool.php
@@ -9,13 +9,12 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Memcached;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Hierarchy\HierarchicalCachePoolTrait;
 use Cache\Hierarchy\HierarchicalPoolInterface;
-use Psr\Cache\CacheItemInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
@@ -45,7 +44,7 @@ class MemcachedCachePool extends AbstractCachePool implements HierarchicalPoolIn
     protected function fetchObjectFromCache($key)
     {
         if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
         return $result;
@@ -80,7 +79,7 @@ class MemcachedCachePool extends AbstractCachePool implements HierarchicalPoolIn
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         if ($ttl === null) {
             $ttl = 0;
@@ -94,7 +93,7 @@ class MemcachedCachePool extends AbstractCachePool implements HierarchicalPoolIn
 
         $key = $this->getHierarchyKey($item->getKey());
 
-        return $this->cache->set($key, serialize([true, $item->get(), []]), $ttl);
+        return $this->cache->set($key, serialize([true, $item->get(), [], $item->getExpirationTimestamp()]), $ttl);
     }
 
     /**

--- a/src/Adapter/PHPArray/ArrayCachePool.php
+++ b/src/Adapter/PHPArray/ArrayCachePool.php
@@ -9,11 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\PHPArray;
 
 use Cache\Adapter\Common\AbstractCachePool;
 use Cache\Adapter\Common\CacheItem;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Hierarchy\HierarchicalCachePoolTrait;
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Taggable\TaggableItemInterface;
@@ -136,7 +136,7 @@ class ArrayCachePool extends AbstractCachePool implements HierarchicalPoolInterf
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         $key               = $this->getHierarchyKey($item->getKey());
         $this->cache[$key] = $item;

--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Predis;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Hierarchy\HierarchicalCachePoolTrait;
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Taggable\TaggableItemInterface;
@@ -60,7 +60,7 @@ class PredisCachePool extends AbstractCachePool implements HierarchicalPoolInter
     protected function fetchObjectFromCache($key)
     {
         if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
         return $result;
@@ -93,14 +93,14 @@ class PredisCachePool extends AbstractCachePool implements HierarchicalPoolInter
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         if ($ttl < 0) {
             return false;
         }
 
         $key  = $this->getHierarchyKey($item->getKey());
-        $data = serialize([true, $item->get(), $item->getTags()]);
+        $data = serialize([true, $item->get(), $item->getTags(), $item->getExpirationTimestamp()]);
 
         if ($ttl === null || $ttl === 0) {
             return 'OK' === $this->cache->set($key, $data)->getPayload();

--- a/src/Adapter/Redis/RedisCachePool.php
+++ b/src/Adapter/Redis/RedisCachePool.php
@@ -9,10 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Redis;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Hierarchy\HierarchicalCachePoolTrait;
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Taggable\TaggableItemInterface;
@@ -47,7 +47,7 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
     protected function fetchObjectFromCache($key)
     {
         if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
-            return [false, null, []];
+            return [false, null, [], null];
         }
 
         return $result;
@@ -78,10 +78,10 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         $key  = $this->getHierarchyKey($item->getKey());
-        $data = serialize([true, $item->get(), $item->getTags()]);
+        $data = serialize([true, $item->get(), $item->getTags(), $item->getExpirationTimestamp()]);
         if ($ttl === null || $ttl === 0) {
             return $this->cache->set($key, $data);
         }

--- a/src/Adapter/Void/VoidCachePool.php
+++ b/src/Adapter/Void/VoidCachePool.php
@@ -9,13 +9,12 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Adapter\Void;
 
 use Cache\Adapter\Common\AbstractCachePool;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Taggable\TaggablePoolInterface;
-use Psr\Cache\CacheItemInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -27,7 +26,7 @@ class VoidCachePool extends AbstractCachePool implements TaggablePoolInterface, 
      */
     protected function fetchObjectFromCache($key)
     {
-        return [false, null, []];
+        return [false, null, [], null];
     }
 
     /**
@@ -49,7 +48,7 @@ class VoidCachePool extends AbstractCachePool implements TaggablePoolInterface, 
     /**
      * {@inheritdoc}
      */
-    protected function storeItemInCache(CacheItemInterface $item, $ttl)
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
     {
         return true;
     }

--- a/src/Encryption/EncryptedItemDecorator.php
+++ b/src/Encryption/EncryptedItemDecorator.php
@@ -9,10 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-
 namespace Cache\Encryption;
 
-use Cache\Adapter\Common\HasExpirationDateInterface;
+use Cache\Adapter\Common\PhpCacheItem;
 use Cache\Taggable\TaggableItemInterface;
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Key;
@@ -23,7 +22,7 @@ use Psr\Cache\CacheItemInterface;
  *
  * @author Daniel Bannert <d.bannert@anolilab.de>
  */
-class EncryptedItemDecorator implements CacheItemInterface, HasExpirationDateInterface, TaggableItemInterface
+class EncryptedItemDecorator implements PhpCacheItem, TaggableItemInterface
 {
     /**
      * @type CacheItemInterface
@@ -96,9 +95,9 @@ class EncryptedItemDecorator implements CacheItemInterface, HasExpirationDateInt
     /**
      * {@inheritdoc}
      */
-    public function getExpirationDate()
+    public function getExpirationTimestamp()
     {
-        return $this->cacheItem->getExpirationDate();
+        return $this->cacheItem->getExpirationTimestamp();
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | https://github.com/php-cache/issues/issues/80 #106 
| License       | MIT
| Doc PR        | 

### Description

We should store the expiration timestamp in the cache storage. We need that to make the chain adapter working properly after a cache item get's removed from an adapter early on in the chain. 

### TODO
* [x] Add tests
* [ ] ~~Add documentation~~
* [x] Updated Changelog.md
