### PR TITLE
Updated licence info + StyleCI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ env:
     - COVERAGE=false
     - TEST="./vendor/bin/phpunit"
 
+branches:
+  except:
+    - /^analysis-.*$/
+    - /^patch-.*$/
+
 matrix:
     include:
       - php: 7.0

--- a/src/Adapter/Apc/ApcCachePool.php
+++ b/src/Adapter/Apc/ApcCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Apc/LICENSE
+++ b/src/Adapter/Apc/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Apc/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Apc/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Apc\Tests;
 

--- a/src/Adapter/Apc/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Apc/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Apcu/LICENSE
+++ b/src/Adapter/Apcu/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Apcu/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Apcu/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Apcu\Tests;
 

--- a/src/Adapter/Apcu/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Apcu/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Chain/CachePoolChain.php
+++ b/src/Adapter/Chain/CachePoolChain.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Chain/Exception/NoPoolAvailableException.php
+++ b/src/Adapter/Chain/Exception/NoPoolAvailableException.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Chain\Exception;
 

--- a/src/Adapter/Chain/Exception/PoolFailedException.php
+++ b/src/Adapter/Chain/Exception/PoolFailedException.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Chain\Exception;
 

--- a/src/Adapter/Chain/LICENSE
+++ b/src/Adapter/Chain/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Chain/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Chain/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Chain\Tests;
 

--- a/src/Adapter/Chain/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Chain/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Chain\Tests;
 

--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/Exception/CacheException.php
+++ b/src/Adapter/Common/Exception/CacheException.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Common\Exception;
 

--- a/src/Adapter/Common/Exception/CachePoolException.php
+++ b/src/Adapter/Common/Exception/CachePoolException.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Common\Exception;
 

--- a/src/Adapter/Common/Exception/InvalidArgumentException.php
+++ b/src/Adapter/Common/Exception/InvalidArgumentException.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Common\Exception;
 

--- a/src/Adapter/Common/HasExpirationTimestampInterface.php
+++ b/src/Adapter/Common/HasExpirationTimestampInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/LICENSE
+++ b/src/Adapter/Common/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Common/PhpCacheItem.php
+++ b/src/Adapter/Common/PhpCacheItem.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/PhpCachePool.php
+++ b/src/Adapter/Common/PhpCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/TagSupportWithArray.php
+++ b/src/Adapter/Common/TagSupportWithArray.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Common/Tests/CacheItemTest.php
+++ b/src/Adapter/Common/Tests/CacheItemTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Doctrine/DoctrineCachePool.php
+++ b/src/Adapter/Doctrine/DoctrineCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Doctrine/LICENSE
+++ b/src/Adapter/Doctrine/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Doctrine/Tests/CreatePoolTrait.php
+++ b/src/Adapter/Doctrine/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Doctrine\Tests;
 

--- a/src/Adapter/Doctrine/Tests/DoctrineAdapterTest.php
+++ b/src/Adapter/Doctrine/Tests/DoctrineAdapterTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Doctrine\Tests;
 

--- a/src/Adapter/Doctrine/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Doctrine/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Doctrine\Tests;
 

--- a/src/Adapter/Doctrine/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Doctrine/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Doctrine\Tests;
 

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Filesystem/LICENSE
+++ b/src/Adapter/Filesystem/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Filesystem/Tests/CreatePoolTrait.php
+++ b/src/Adapter/Filesystem/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Filesystem\Tests;
 

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Filesystem/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Filesystem/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Filesystem\Tests;
 

--- a/src/Adapter/Filesystem/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Filesystem/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Filesystem\Tests;
 

--- a/src/Adapter/Memcache/LICENSE
+++ b/src/Adapter/Memcache/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Memcache/MemcacheCachePool.php
+++ b/src/Adapter/Memcache/MemcacheCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Memcache/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Memcache/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Memcache\Tests;
 

--- a/src/Adapter/Memcache/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Memcache/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Memcached/LICENSE
+++ b/src/Adapter/Memcached/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Memcached/MemcachedCachePool.php
+++ b/src/Adapter/Memcached/MemcachedCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Memcached/Tests/CreatePoolTrait.php
+++ b/src/Adapter/Memcached/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Memcached\Tests;
 

--- a/src/Adapter/Memcached/Tests/IntegrationHierarchyTest.php
+++ b/src/Adapter/Memcached/Tests/IntegrationHierarchyTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Memcached\Tests;
 

--- a/src/Adapter/Memcached/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Memcached/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Memcached\Tests;
 

--- a/src/Adapter/Memcached/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Memcached/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Memcached\Tests;
 

--- a/src/Adapter/MongoDB/LICENSE
+++ b/src/Adapter/MongoDB/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/MongoDB/MongoDBCachePool.php
+++ b/src/Adapter/MongoDB/MongoDBCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/MongoDB/Tests/CreateServerTrait.php
+++ b/src/Adapter/MongoDB/Tests/CreateServerTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\MongoDB\Tests;
 

--- a/src/Adapter/MongoDB/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/MongoDB/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\MongoDB\Tests;
 

--- a/src/Adapter/MongoDB/Tests/IntegrationTagTest.php
+++ b/src/Adapter/MongoDB/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/PHPArray/ArrayCachePool.php
+++ b/src/Adapter/PHPArray/ArrayCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/PHPArray/LICENSE
+++ b/src/Adapter/PHPArray/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
+++ b/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\PHPArray\Tests;
 

--- a/src/Adapter/PHPArray/Tests/CreatePoolTrait.php
+++ b/src/Adapter/PHPArray/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\PHPArray\Tests;
 

--- a/src/Adapter/PHPArray/Tests/IntegrationHierarchicalTest.php
+++ b/src/Adapter/PHPArray/Tests/IntegrationHierarchicalTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\PHPArray\Tests;
 

--- a/src/Adapter/PHPArray/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/PHPArray/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\PHPArray\Tests;
 

--- a/src/Adapter/PHPArray/Tests/IntegrationTagTest.php
+++ b/src/Adapter/PHPArray/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\PHPArray\Tests;
 

--- a/src/Adapter/Predis/LICENSE
+++ b/src/Adapter/Predis/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Predis/Tests/CreatePoolTrait.php
+++ b/src/Adapter/Predis/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Predis\Tests;
 

--- a/src/Adapter/Predis/Tests/IntegrationHierarchyTest.php
+++ b/src/Adapter/Predis/Tests/IntegrationHierarchyTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Predis\Tests;
 

--- a/src/Adapter/Predis/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Predis/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Predis\Tests;
 

--- a/src/Adapter/Predis/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Predis/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Predis\Tests;
 

--- a/src/Adapter/Redis/LICENSE
+++ b/src/Adapter/Redis/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Redis/RedisCachePool.php
+++ b/src/Adapter/Redis/RedisCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Redis/Tests/CreatePoolTrait.php
+++ b/src/Adapter/Redis/Tests/CreatePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Redis\Tests;
 

--- a/src/Adapter/Redis/Tests/IntegrationHierarchyTest.php
+++ b/src/Adapter/Redis/Tests/IntegrationHierarchyTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Redis\Tests;
 

--- a/src/Adapter/Redis/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Redis/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Redis\Tests;
 

--- a/src/Adapter/Redis/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Redis/Tests/IntegrationTagTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Redis\Tests;
 

--- a/src/Adapter/Void/LICENSE
+++ b/src/Adapter/Void/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Adapter/Void/Tests/IntegrationHierarchyTest.php
+++ b/src/Adapter/Void/Tests/IntegrationHierarchyTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Void\Tests;
 

--- a/src/Adapter/Void/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Void/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Adapter\Void\Tests;
 

--- a/src/Adapter/Void/Tests/IntegrationTagTest.php
+++ b/src/Adapter/Void/Tests/IntegrationTagTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Adapter/Void/VoidCachePool.php
+++ b/src/Adapter/Void/VoidCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Bridge/Doctrine/DoctrineCacheBridge.php
+++ b/src/Bridge/Doctrine/DoctrineCacheBridge.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Bridge\Doctrine;
 

--- a/src/Bridge/Doctrine/LICENSE
+++ b/src/Bridge/Doctrine/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Bridge/Doctrine/Tests/DoctrineCacheBridgeTest.php
+++ b/src/Bridge/Doctrine/Tests/DoctrineCacheBridgeTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Bridge\Doctrine\Tests;
 

--- a/src/Encryption/EncryptedCachePool.php
+++ b/src/Encryption/EncryptedCachePool.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Encryption/EncryptedItemDecorator.php
+++ b/src/Encryption/EncryptedItemDecorator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Encryption/Tests/IntegrationPoolTest.php
+++ b/src/Encryption/Tests/IntegrationPoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Encryption\Tests;
 

--- a/src/Hierarchy/HierarchicalCachePoolTrait.php
+++ b/src/Hierarchy/HierarchicalCachePoolTrait.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Hierarchy;
 

--- a/src/Hierarchy/HierarchicalPoolInterface.php
+++ b/src/Hierarchy/HierarchicalPoolInterface.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Hierarchy;
 

--- a/src/Hierarchy/LICENSE
+++ b/src/Hierarchy/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Hierarchy/Tests/Helper/CachePool.php
+++ b/src/Hierarchy/Tests/Helper/CachePool.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Hierarchy\Tests\Helper;
 

--- a/src/Hierarchy/Tests/HierarchicalCachePoolTest.php
+++ b/src/Hierarchy/Tests/HierarchicalCachePoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Hierarchy\Tests;
 

--- a/src/Namespaced/LICENSE
+++ b/src/Namespaced/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Namespaced/NamespacedCachePool.php
+++ b/src/Namespaced/NamespacedCachePool.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Namespaced;
 

--- a/src/Namespaced/Tests/HelperInterface.php
+++ b/src/Namespaced/Tests/HelperInterface.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Namespaced\Tests;
 

--- a/src/Namespaced/Tests/NamespacedCachePoolTest.php
+++ b/src/Namespaced/Tests/NamespacedCachePoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Namespaced\Tests;
 

--- a/src/Prefixed/LICENSE
+++ b/src/Prefixed/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Prefixed/PrefixedCachePool.php
+++ b/src/Prefixed/PrefixedCachePool.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Prefixed;
 

--- a/src/Prefixed/Tests/PrefixedCachePoolTest.php
+++ b/src/Prefixed/Tests/PrefixedCachePoolTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Prefixed\Tests;
 

--- a/src/SessionHandler/LICENSE
+++ b/src/SessionHandler/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/SessionHandler/Psr6SessionHandler.php
+++ b/src/SessionHandler/Psr6SessionHandler.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\SessionHandler;
 

--- a/src/SessionHandler/Tests/Psr6SessionHandlerTest.php
+++ b/src/SessionHandler/Tests/Psr6SessionHandlerTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\SessionHandler\Tests;
 

--- a/src/TagInterop/TaggableCacheItemInterface.php
+++ b/src/TagInterop/TaggableCacheItemInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/TagInterop/TaggableCacheItemPoolInterface.php
+++ b/src/TagInterop/TaggableCacheItemPoolInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/LICENSE
+++ b/src/Taggable/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Aaron Scherer
+Copyright (c) 2015 Aaron Scherer, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Taggable/TaggableItemInterface.php
+++ b/src/Taggable/TaggableItemInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/TaggablePSR6ItemAdapter.php
+++ b/src/Taggable/TaggablePSR6ItemAdapter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/TaggablePoolInterface.php
+++ b/src/Taggable/TaggablePoolInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/TaggablePoolTrait.php
+++ b/src/Taggable/TaggablePoolTrait.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/src/Taggable/Tests/SameTagPoolTaggablePSR6AdapterTest.php
+++ b/src/Taggable/Tests/SameTagPoolTaggablePSR6AdapterTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Taggable\Tests;
 

--- a/src/Taggable/Tests/SeparateTagPoolPSR6AdapterTest.php
+++ b/src/Taggable/Tests/SeparateTagPoolPSR6AdapterTest.php
@@ -3,12 +3,11 @@
 /*
  * This file is part of php-cache organization.
  *
- * (c) 2015-2016 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
-
 
 namespace Cache\Taggable\Tests;
 


### PR DESCRIPTION
Updating license info and style CI fixes

Copy right notice should contain the year of creation. We do not have to have "2015-2017"