### PR TITLE
Using better composer flags to speed up travis

### DIFF
--- a/build/runTest.sh
+++ b/build/runTest.sh
@@ -16,6 +16,6 @@ printf "************************************************************************
 
 if [ "$SLUG" = 'cache/cache' ]; then composer require --no-update mongodb/mongodb:^1.0 predis/predis:^1.0; fi
 
-composer update --no-interaction || exit 1
+composer update --no-interaction --prefer-stable --no-progress --prefer-dist || exit 1
 
 sh -c "$TEST" || exit 1

--- a/src/Adapter/Apc/.travis.yml
+++ b/src/Adapter/Apc/.travis.yml
@@ -25,7 +25,7 @@ before_install:
     - phpenv config-add ./apcu_bc.ini
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Apcu/.travis.yml
+++ b/src/Adapter/Apcu/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - yes '' | pecl install apcu
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Chain/.travis.yml
+++ b/src/Adapter/Chain/.travis.yml
@@ -13,7 +13,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Common/.travis.yml
+++ b/src/Adapter/Common/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Doctrine/.travis.yml
+++ b/src/Adapter/Doctrine/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Filesystem/.travis.yml
+++ b/src/Adapter/Filesystem/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Memcache/.travis.yml
+++ b/src/Adapter/Memcache/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     - bash <(curl -s https://raw.githubusercontent.com/php-cache/cache/master/build/php/5.6/Memcache.sh)
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Memcached/.travis.yml
+++ b/src/Adapter/Memcached/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     - bash <(curl -s https://raw.githubusercontent.com/php-cache/cache/master/build/php/7.0/Memcached.sh)
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/MongoDB/.travis.yml
+++ b/src/Adapter/MongoDB/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     - bash <(curl -s https://raw.githubusercontent.com/php-cache/cache/master/build/php/7.0/MongoDB.sh)
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/PHPArray/.travis.yml
+++ b/src/Adapter/PHPArray/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Predis/.travis.yml
+++ b/src/Adapter/Predis/.travis.yml
@@ -13,7 +13,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Redis/.travis.yml
+++ b/src/Adapter/Redis/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     - bash <(curl -s https://raw.githubusercontent.com/php-cache/cache/master/build/php/7.0/Redis.sh)
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Adapter/Void/.travis.yml
+++ b/src/Adapter/Void/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Bridge/Doctrine/.travis.yml
+++ b/src/Bridge/Doctrine/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Bridge/SimpleCache/.travis.yml
+++ b/src/Bridge/SimpleCache/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Encryption/.travis.yml
+++ b/src/Encryption/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Hierarchy/.travis.yml
+++ b/src/Hierarchy/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Namespaced/.travis.yml
+++ b/src/Namespaced/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Prefixed/.travis.yml
+++ b/src/Prefixed/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/SessionHandler/.travis.yml
+++ b/src/SessionHandler/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/TagInterop/.travis.yml
+++ b/src/TagInterop/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/Taggable/.travis.yml
+++ b/src/Taggable/.travis.yml
@@ -10,7 +10,7 @@ cache:
       - "$HOME/.composer/cache"
 
 install:
-    - composer update
+    - composer update --prefer-dist --prefer-stable
 
 script:
     - ./vendor/bin/phpunit --coverage-clover=coverage.xml


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

Added some composer flag to run tests faster. When min-stabillity:dev was added to the composer.json we started to clone dependencies. That is awfully slow. Now it will only take dev-master dependencies if there is no stable version. 

| Test | Before | After |
| ---- | -------| ----- |
| Coverage | 14 min | 7 min |
| Normal | 12 min | 6 min |


