### PR TITLE
Fix dependendcy on hierarchical-cache

### DIFF
--- a/src/Adapter/Void/composer.json
+++ b/src/Adapter/Void/composer.json
@@ -28,7 +28,7 @@
         "psr/cache":                "^1.0",
         "psr/simple-cache":         "^1.0",
         "cache/adapter-common":     "^0.4",
-        "cache/hierarchical-cache": "^0.3"
+        "cache/hierarchical-cache": "^0.4"
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0 || ^5.1",

--- a/src/Prefixed/composer.json
+++ b/src/Prefixed/composer.json
@@ -20,7 +20,7 @@
     "require":           {
         "php":                      "^5.6 || ^7.0",
         "psr/cache":                "^1.0",
-        "cache/hierarchical-cache": "^0.3"
+        "cache/hierarchical-cache": "^0.4"
     },
     "require-dev":       {
         "phpunit/phpunit":         "^4.0 || ^5.1",


### PR DESCRIPTION
All adapters which use cache/hierarchical-cache use "^0.4", except this void adapter makes it unable to install

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #98
| License       | MIT

### Description

All adapters which use cache/hierarchical-cache use "^0.4", except this void adapter makes it unable to install