### PR TITLE
Update changelog to notify PHP 5.5 support drop

### DIFF
--- a/src/Adapter/Apcu/Changelog.md
+++ b/src/Adapter/Apcu/Changelog.md
@@ -20,6 +20,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 * `CacheItem::getExpirationDate()`. Use `CacheItem::getExpirationTimestamp()`
 * `CacheItem::getTags()`. Use `CacheItem::getPreviousTags()`
 * `CacheItem::addTag()`. Use `CacheItem::setTags()`
+* Dropped PHP 5.5 support
 
 ## 0.2.2
 


### PR DESCRIPTION
Thought this might be useful to save the next person having to git blame the `composer.json`

| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

### Description

Added a line to the changelog to notify which version dropped PHP 5.5 support.

