### PR TITLE
fix merging loaded items

### DIFF
--- a/src/Adapter/Chain/CachePoolChain.php
+++ b/src/Adapter/Chain/CachePoolChain.php
@@ -42,7 +42,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     /**
      * @param array $pools
      * @param array $options {
-     * @type  bool $skip_on_failure If true we will remove a pool form the chain if it fails.
+     * @type  bool  $skip_on_failure If true we will remove a pool form the chain if it fails.
      *                      }
      */
     public function __construct(array $pools, array $options = [])
@@ -61,8 +61,8 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
      */
     public function getItem($key)
     {
-        $found = false;
-        $result = null;
+        $found     = false;
+        $result    = null;
         $needsSave = [];
 
         foreach ($this->getPools() as $poolKey => $pool) {
@@ -70,7 +70,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
                 $item = $pool->getItem($key);
 
                 if ($item->isHit()) {
-                    $found = true;
+                    $found  = true;
                     $result = $item;
                     break;
                 }
@@ -97,9 +97,9 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
      */
     public function getItems(array $keys = [])
     {
-        $hits = [];
+        $hits        = [];
         $loadedItems = [];
-        $keysCount = count($keys);
+        $keysCount   = count($keys);
         foreach ($this->getPools() as $poolKey => $pool) {
             try {
                 $items = $pool->getItems($keys);
@@ -289,9 +289,9 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     /**
      * Logs with an arbitrary level if the logger exists.
      *
-     * @param mixed $level
+     * @param mixed  $level
      * @param string $message
-     * @param array $context
+     * @param array  $context
      */
     protected function log($level, $message, array $context = [])
     {
@@ -313,8 +313,8 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     }
 
     /**
-     * @param string $poolKey
-     * @param string $operation
+     * @param string             $poolKey
+     * @param string             $operation
      * @param CachePoolException $exception
      *
      * @throws PoolFailedException

--- a/src/Adapter/Chain/CachePoolChain.php
+++ b/src/Adapter/Chain/CachePoolChain.php
@@ -42,12 +42,12 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     /**
      * @param array $pools
      * @param array $options {
-     * @type  bool  $skip_on_failure If true we will remove a pool form the chain if it fails.
+     * @type  bool $skip_on_failure If true we will remove a pool form the chain if it fails.
      *                      }
      */
     public function __construct(array $pools, array $options = [])
     {
-        $this->pools   = $pools;
+        $this->pools = $pools;
 
         if (!isset($options['skip_on_failure'])) {
             $options['skip_on_failure'] = false;
@@ -61,8 +61,8 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
      */
     public function getItem($key)
     {
-        $found     = false;
-        $result    = null;
+        $found = false;
+        $result = null;
         $needsSave = [];
 
         foreach ($this->getPools() as $poolKey => $pool) {
@@ -70,7 +70,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
                 $item = $pool->getItem($key);
 
                 if ($item->isHit()) {
-                    $found  = true;
+                    $found = true;
                     $result = $item;
                     break;
                 }
@@ -97,8 +97,9 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
      */
     public function getItems(array $keys = [])
     {
-        $hits  = [];
-        $items = [];
+        $hits = [];
+        $loadedItems = [];
+        $keysCount = count($keys);
         foreach ($this->getPools() as $poolKey => $pool) {
             try {
                 $items = $pool->getItems($keys);
@@ -107,10 +108,11 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
                 foreach ($items as $item) {
                     if ($item->isHit()) {
                         $hits[$item->getKey()] = $item;
+                        unset($keys[array_search($item->getKey(), $keys)]);
                     }
+                    $loadedItems[$item->getKey()] = $item;
                 }
-
-                if (count($hits) === count($keys)) {
+                if (count($hits) === $keysCount) {
                     return $hits;
                 }
             } catch (CachePoolException $e) {
@@ -118,8 +120,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
             }
         }
 
-        // We need to accept that some items where not hits.
-        return array_merge($hits, $items);
+        return array_merge($hits, $loadedItems);
     }
 
     /**
@@ -288,9 +289,9 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     /**
      * Logs with an arbitrary level if the logger exists.
      *
-     * @param mixed  $level
+     * @param mixed $level
      * @param string $message
-     * @param array  $context
+     * @param array $context
      */
     protected function log($level, $message, array $context = [])
     {
@@ -312,8 +313,8 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
     }
 
     /**
-     * @param string             $poolKey
-     * @param string             $operation
+     * @param string $poolKey
+     * @param string $operation
      * @param CachePoolException $exception
      *
      * @throws PoolFailedException
@@ -326,7 +327,8 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
 
         $this->log(
             'warning',
-            sprintf('Removing pool "%s" from chain because it threw an exception when executing "%s"', $poolKey, $operation),
+            sprintf('Removing pool "%s" from chain because it threw an exception when executing "%s"', $poolKey,
+                $operation),
             ['exception' => $exception]
         );
 

--- a/src/Adapter/Chain/CachePoolChain.php
+++ b/src/Adapter/Chain/CachePoolChain.php
@@ -120,7 +120,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
             }
         }
 
-        return array_merge($hits, $loadedItems);
+        return array_merge($loadedItems, $hits);
     }
 
     /**
@@ -327,8 +327,7 @@ class CachePoolChain implements CacheItemPoolInterface, LoggerAwareInterface
 
         $this->log(
             'warning',
-            sprintf('Removing pool "%s" from chain because it threw an exception when executing "%s"', $poolKey,
-                $operation),
+            sprintf('Removing pool "%s" from chain because it threw an exception when executing "%s"', $poolKey, $operation),
             ['exception' => $exception]
         );
 


### PR DESCRIPTION
fix merging loaded items, when return type of getItems method from ch
ained pool is Generator instead of array
add unsetting loaded key from next chain pool loading for better performance
fix psr2 code style

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any


