### PR TITLE
Namespaced pool should implement HierarchicalPool

### DIFF
--- a/src/Namespaced/NamespacedCachePool.php
+++ b/src/Namespaced/NamespacedCachePool.php
@@ -13,7 +13,6 @@ namespace Cache\Namespaced;
 
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Psr\Cache\CacheItemInterface;
-use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Prefix all the stored items with a namespace. Also make sure you can clear all items
@@ -21,7 +20,7 @@ use Psr\Cache\CacheItemPoolInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class NamespacedCachePool implements CacheItemPoolInterface
+class NamespacedCachePool implements HierarchicalPoolInterface
 {
     /**
      * @type HierarchicalPoolInterface

--- a/src/Prefixed/PrefixedCachePool.php
+++ b/src/Prefixed/PrefixedCachePool.php
@@ -11,7 +11,6 @@
 
 namespace Cache\Prefixed;
 
-use Cache\Hierarchy\HierarchicalPoolInterface;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -23,7 +22,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class PrefixedCachePool implements CacheItemPoolInterface
 {
     /**
-     * @type HierarchicalPoolInterface
+     * @type CacheItemPoolInterface
      */
     private $cachePool;
 


### PR DESCRIPTION
Fix Prefixed pool property annotation
Fix php-cache/issues#105

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 105
| License       | MIT

