### PR TITLE
Make us independent from PHPCache

### DIFF
--- a/src/Taggable/Changelog.md
+++ b/src/Taggable/Changelog.md
@@ -4,6 +4,14 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+## 1.0.0
+
+### Changed
+
+* We do not throw `Cache\Adapter\Common\Exception\InvalidArgumentException` anymore. Instead we throw 
+`Cache\Taggable\Exception\InvalidArgumentException`. Both exceptions do implement `Psr\Cache\InvalidArgumentException`
+* We do not require `cache/adapter-common`
+
 ## 0.5.1
 
 ### Fixed

--- a/src/Taggable/Exception/InvalidArgumentException.php
+++ b/src/Taggable/Exception/InvalidArgumentException.php
@@ -11,6 +11,6 @@
 
 namespace Cache\Taggable\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements \Psr\SimpleCache\InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements \Psr\Cache\InvalidArgumentException
 {
 }

--- a/src/Taggable/Exception/InvalidArgumentException.php
+++ b/src/Taggable/Exception/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Taggable\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements \Psr\SimpleCache\InvalidArgumentException
+{
+}

--- a/src/Taggable/TaggablePSR6ItemAdapter.php
+++ b/src/Taggable/TaggablePSR6ItemAdapter.php
@@ -11,7 +11,7 @@
 
 namespace Cache\Taggable;
 
-use Cache\Adapter\Common\Exception\InvalidArgumentException;
+use Cache\Taggable\Exception\InvalidArgumentException;
 use Cache\TagInterop\TaggableCacheItemInterface;
 use Psr\Cache\CacheItemInterface;
 
@@ -22,29 +22,29 @@ use Psr\Cache\CacheItemInterface;
  * adapter.
  *
  * This adapter stores tags along with the cached value, by storing wrapping
- * the item in an array structure containing both.
+ * the item in an array structure containing both
  *
  * @author Magnus Nordlander <magnus@fervo.se>
  */
 class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
 {
     /**
-     * @type bool
+     * @var bool
      */
     private $initialized = false;
 
     /**
-     * @type CacheItemInterface
+     * @var CacheItemInterface
      */
     private $cacheItem;
 
     /**
-     * @type array<string>
+     * @var array<string>
      */
     private $prevTags = [];
 
     /**
-     * @type array<string>
+     * @var array<string>
      */
     private $tags = [];
 
@@ -115,7 +115,7 @@ class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
 
         $this->cacheItem->set([
             'value' => $value,
-            'tags'  => $this->tags,
+            'tags' => $this->tags,
         ]);
 
         return $this;
@@ -202,7 +202,7 @@ class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
     {
         $this->cacheItem->set([
             'value' => $this->get(),
-            'tags'  => $this->tags,
+            'tags' => $this->tags,
         ]);
     }
 

--- a/src/Taggable/TaggablePSR6ItemAdapter.php
+++ b/src/Taggable/TaggablePSR6ItemAdapter.php
@@ -29,22 +29,22 @@ use Psr\Cache\CacheItemInterface;
 class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
 {
     /**
-     * @var bool
+     * @type bool
      */
     private $initialized = false;
 
     /**
-     * @var CacheItemInterface
+     * @type CacheItemInterface
      */
     private $cacheItem;
 
     /**
-     * @var array<string>
+     * @type array<string>
      */
     private $prevTags = [];
 
     /**
-     * @var array<string>
+     * @type array<string>
      */
     private $tags = [];
 
@@ -115,7 +115,7 @@ class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
 
         $this->cacheItem->set([
             'value' => $value,
-            'tags' => $this->tags,
+            'tags'  => $this->tags,
         ]);
 
         return $this;
@@ -202,7 +202,7 @@ class TaggablePSR6ItemAdapter implements TaggableCacheItemInterface
     {
         $this->cacheItem->set([
             'value' => $this->get(),
-            'tags' => $this->tags,
+            'tags'  => $this->tags,
         ]);
     }
 

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -40,12 +40,12 @@ use Psr\Cache\CacheItemPoolInterface;
 class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
 {
     /**
-     * @type CacheItemPoolInterface
+     * @var CacheItemPoolInterface
      */
     private $cachePool;
 
     /**
-     * @type CacheItemPoolInterface
+     * @var CacheItemPoolInterface
      */
     private $tagStorePool;
 
@@ -64,8 +64,8 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
     }
 
     /**
-     * @param CacheItemPoolInterface      $cachePool    The pool to which to add tagging capabilities.
-     * @param CacheItemPoolInterface|null $tagStorePool The pool to store tags in. If null is passed, the main pool is used.
+     * @param CacheItemPoolInterface      $cachePool    The pool to which to add tagging capabilities
+     * @param CacheItemPoolInterface|null $tagStorePool The pool to store tags in. If null is passed, the main pool is used
      *
      * @return TaggableCacheItemPoolInterface
      */

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -40,12 +40,12 @@ use Psr\Cache\CacheItemPoolInterface;
 class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
 {
     /**
-     * @var CacheItemPoolInterface
+     * @type CacheItemPoolInterface
      */
     private $cachePool;
 
     /**
-     * @var CacheItemPoolInterface
+     * @type CacheItemPoolInterface
      */
     private $tagStorePool;
 

--- a/src/Taggable/composer.json
+++ b/src/Taggable/composer.json
@@ -32,7 +32,6 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/cache": "^1.0",
-        "cache/adapter-common": "^1.0",
         "cache/tag-interop": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
We were only using cache/adapter-common for one exception. That is not enough. We should be independent like the SimpleCache is. 