### PR TITLE
add PSR-16 SimpleCacheChain and SimpleArrayCache

### DIFF
--- a/src/Adapter/Chain/SimpleCacheChain.php
+++ b/src/Adapter/Chain/SimpleCacheChain.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace Cache\Adapter\Chain;
+
+use Cache\Adapter\Chain\Exception\NoPoolAvailableException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Psr\SimpleCache\CacheException;
+use Psr\SimpleCache\CacheInterface;
+
+class SimpleCacheChain implements CacheInterface
+{
+    /**
+     * @type CacheInterface[]
+     */
+    private $pools;
+    
+    /**
+     * @type array
+     */
+    private $options;
+    
+    /**
+     * @type LoggerInterface
+     */
+    private $logger;
+    
+    /**
+     * @param array $pools
+     * @param array $options {
+     * @type bool $skip_on_failure If true we will remove a pool form the chain if it fails.
+     *                       }
+     * @param LoggerInterface|null $logger
+     * @throws NoPoolAvailableException
+     */
+    public function __construct(array $pools, array $options = [], LoggerInterface $logger = null)
+    {
+        if (empty($pools)) {
+            throw new NoPoolAvailableException('No valid cache pool available for the chain.');
+        }
+        
+        $this->pools = $pools;
+        
+        if (!isset($options['skip_on_failure'])) {
+            $options['skip_on_failure'] = false;
+        }
+        
+        $this->options = $options;
+        $this->logger = $logger ?: new NullLogger();
+    }
+    
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get($key, $default = null)
+    {
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $value = $pool->get($key, $default);
+                
+                if ($value !== $default) {
+                    return $value;
+                }
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+        
+        return $default;
+    }
+    
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $result = true;
+        
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $result = $pool->set($key, $value, $ttl) && $result;
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return true;
+    }
+    
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        $result = true;
+        
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $result = $result && $pool->delete($key);
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return $result;
+    }
+    
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     */
+    public function clear()
+    {
+        $result = true;
+        
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $result = $result && $pool->clear();
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return $result;
+    }
+    
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $values = [];
+        
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $values[] = $pool->getMultiple($keys, $default);
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        // Flatten multi-dimensional array of values.
+        return call_user_func_array('array_merge', $values);
+    }
+    
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $result = true;
+    
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $result = $pool->setMultiple($values, $ttl) && $result;
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return true;
+    }
+    
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $result = true;
+        
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                $result = $result && $pool->deleteMultiple($keys);
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return $result;
+    }
+    
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     * @throws \Psr\SimpleCache\CacheException
+     * @throws NoPoolAvailableException
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        foreach ($this->pools as $poolKey => $pool) {
+            try {
+                if ($pool->has($key)) {
+                    return true;
+                }
+            } catch (CacheException $e) {
+                $this->handleException($poolKey, __FUNCTION__, $e);
+            }
+        }
+    
+        return false;
+    }
+    
+    /**
+     * Logs with an arbitrary level if the logger exists.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     */
+    protected function log($level, $message, array $context = [])
+    {
+        if ($this->logger !== null) {
+            $this->logger->log($level, $message, $context);
+        }
+    }
+    
+    /**
+     * @param string $poolKey
+     * @param string $operation
+     * @param CacheException $exception
+     * @throws CacheException
+     */
+    private function handleException($poolKey, $operation, CacheException $exception)
+    {
+        if (!$this->options['skip_on_failure']) {
+            throw $exception;
+        }
+        
+        $this->log(
+            'warning',
+            sprintf('Removing pool "%s" from chain because it threw an exception when executing "%s"', $poolKey, $operation),
+            ['exception' => $exception]
+        );
+        
+        unset($this->pools[$poolKey]);
+    }
+}

--- a/src/Adapter/Chain/Tests/CachePoolChainTest.php
+++ b/src/Adapter/Chain/Tests/CachePoolChainTest.php
@@ -13,10 +13,13 @@ namespace Cache\Adapter\Chain\Tests;
 
 use Cache\Adapter\Chain\CachePoolChain;
 use Cache\Adapter\Common\CacheItem;
+use Cache\Adapter\Common\Exception\CachePoolException;
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Class ChainPoolTest.
+ * @covers \Cache\Adapter\Chain\CachePoolChain
  */
 class CachePoolChainTest extends \PHPUnit_Framework_TestCase
 {
@@ -93,19 +96,388 @@ class CachePoolChainTest extends \PHPUnit_Framework_TestCase
 
     public function testGetItemsWithEmptyCache()
     {
-        $firstPool  = new ArrayCachePool();
+        $firstPool = new ArrayCachePool();
         $secondPool = new ArrayCachePool();
-        $chainPool  = new CachePoolChain([$firstPool, $secondPool]);
-
-        $key  = 'test_key';
+        $chainPool = new CachePoolChain([$firstPool, $secondPool]);
+    
+        $key = 'test_key';
         $key2 = 'test_key2';
-
+    
         $items = $chainPool->getItems([$key, $key2]);
-
+    
         $this->assertArrayHasKey($key, $items);
         $this->assertArrayHasKey($key2, $items);
-
+    
         $this->assertFalse($items[$key]->isHit());
         $this->assertFalse($items[$key2]->isHit());
+    }
+    
+    public function testWritesOneItemToMultiplePools()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem($key));
+        
+        $secondPool = new ArrayCachePool();
+        self::assertFalse($secondPool->hasItem($key));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $result = $chain->save(new CacheItem($key, true, $value));
+        
+        self::assertTrue($result);
+        
+        self::assertTrue($firstPool->hasItem($key));
+        self::assertTrue($secondPool->hasItem($key));
+    }
+    
+    public function testReadsOneItemFromFirstPool()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new ArrayCachePool();
+        $firstPool->save(new CacheItem($key, true, $value));
+        self::assertTrue($firstPool->hasItem($key));
+        
+        $secondPool = new ArrayCachePool();
+        self::assertFalse($secondPool->hasItem($key));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $item = $chain->getItem($key);
+        self::assertInstanceOf(CacheItem::class, $item);
+        self::assertSame($value, $item->get());
+    }
+    
+    public function testReadsOneItemFromSecondPoolAndRestoresIntoFirstPool()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem($key));
+        
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($key, true, $value));
+        self::assertTrue($secondPool->hasItem($key));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $item = $chain->getItem($key);
+        self::assertInstanceOf(CacheItem::class, $item);
+        self::assertSame($value, $item->get());
+        
+        self::assertTrue($firstPool->hasItem($key));
+        self::assertTrue($secondPool->hasItem($key));
+    }
+    
+    /**
+     * @expectedException \Psr\Cache\CacheException
+     */
+    public function testDefaultBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+    
+        $firstPool = $this->getMockBuilder(CacheItemPoolInterface::class)
+            ->getMock();
+        $firstPool->method('getItem')
+            ->with($key)
+            ->willThrowException(new CachePoolException());
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($key, true, $value));
+        self::assertTrue($secondPool->hasItem($key));
+    
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $chain->getItem($key);
+    }
+    
+    /**
+     * @expectedException \Psr\Cache\CacheException
+     */
+    public function testDisabledBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+    
+        $firstPool = $this->getMockBuilder(CacheItemPoolInterface::class)
+            ->getMock();
+        $firstPool->method('getItem')
+            ->with($key)
+            ->willThrowException(new CachePoolException());
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($key, true, $value));
+        self::assertTrue($secondPool->hasItem($key));
+    
+        $pools = [
+            $firstPool,
+            $secondPool,
+        ];
+    
+        $options = [
+            'skip_on_failure' => false,
+        ];
+        
+        $chain = new CachePoolChain($pools, $options);
+    
+        $chain->getItem($key);
+    }
+    
+    public function testEnabledBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+    
+        $firstPool = $this->getMockBuilder(CacheItemPoolInterface::class)
+            ->getMock();
+        $firstPool->method('getItem')
+            ->with($key)
+            ->willThrowException(new CachePoolException());
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($key, true, $value));
+        self::assertTrue($secondPool->hasItem($key));
+    
+        $pools = [
+            $firstPool,
+            $secondPool,
+        ];
+    
+        $options = [
+            'skip_on_failure' => true,
+        ];
+    
+        $chain = new CachePoolChain($pools, $options);
+    
+        $item = $chain->getItem($key);
+        
+        self::assertSame($value, $item->get());
+    }
+    
+    public function testReadsManyItems()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+    
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+    
+        $pool = new ArrayCachePool();
+        $pool->save(new CacheItem($firstKey, true, $firstValue));
+        self::assertTrue($pool->hasItem($firstKey));
+        
+        $pool->save(new CacheItem($secondKey, true, $secondValue));
+        self::assertTrue($pool->hasItem($secondKey));
+        
+        $chain = new CachePoolChain([
+            $pool,
+        ]);
+        
+        $items = $chain->getItems([
+            $firstKey,
+            $secondKey,
+        ]);
+        
+        self::assertInstanceOf(CacheItem::class, $firstItem = $items[$firstKey]);
+        self::assertSame($firstValue, $firstItem->get());
+        
+        self::assertInstanceOf(CacheItem::class, $secondItem = $items[$secondKey]);
+        self::assertSame($secondValue, $secondItem->get());
+    }
+    
+    public function testReadsManyMissedItems()
+    {
+        $pool = new ArrayCachePool();
+        
+        $chain = new CachePoolChain([
+            $pool,
+        ]);
+        
+        $items = $chain->getItems([
+            'FooBar',
+            'FizBuz',
+        ]);
+        
+        self::assertInstanceOf(CacheItem::class, $firstItem = $items['FooBar']);
+        self::assertNull($firstItem->get());
+        
+        self::assertInstanceOf(CacheItem::class, $secondItem = $items['FizBuz']);
+        self::assertNull($secondItem->get());
+    }
+    
+    public function testHasItem()
+    {
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem('FooBar'));
+        
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem('FooBar', true, 'FizBuz'));
+        self::assertTrue($secondPool->hasItem('FooBar'));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertTrue($chain->hasItem('FooBar'));
+    }
+    
+    public function testNotHasItem()
+    {
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem('FooBar'));
+    
+        $secondPool = new ArrayCachePool();
+        self::assertFalse($secondPool->hasItem('FooBar'));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertFalse($chain->hasItem('FooBar'));
+    }
+    
+    public function testClear()
+    {
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem('FooBar'));
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem('FooBar', true, 'FizBuz'));
+        self::assertTrue($secondPool->hasItem('FooBar'));
+    
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+    
+        self::assertTrue($chain->hasItem('FooBar'));
+        
+        self::assertTrue($chain->clear());
+        
+        self::assertFalse($chain->hasItem('FooBar'));
+    }
+    
+    public function testDeleteItem()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+    
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+    
+        $firstPool = new ArrayCachePool();
+        $firstPool->save(new CacheItem($firstKey, true, $firstValue));
+        self::assertTrue($firstPool->hasItem($firstKey));
+        
+        $firstPool->save(new CacheItem($secondKey, true, $secondValue));
+        self::assertTrue($firstPool->hasItem($secondKey));
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($firstKey, true, $firstValue));
+        self::assertTrue($secondPool->hasItem($firstKey));
+    
+        $secondPool->save(new CacheItem($secondKey, true, $secondValue));
+        self::assertTrue($secondPool->hasItem($secondKey));
+    
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+    
+        self::assertTrue($chain->hasItem($firstKey));
+        self::assertTrue($chain->hasItem($secondKey));
+        
+        self::assertTrue($chain->deleteItem($firstKey));
+        
+        self::assertFalse($chain->hasItem($firstKey));
+        self::assertTrue($chain->hasItem($secondKey));
+    }
+    
+    public function testDeleteItems()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+    
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+    
+        $firstPool = new ArrayCachePool();
+        $firstPool->save(new CacheItem($firstKey, true, $firstValue));
+        self::assertTrue($firstPool->hasItem($firstKey));
+    
+        $firstPool->save(new CacheItem($secondKey, true, $secondValue));
+        self::assertTrue($firstPool->hasItem($secondKey));
+    
+        $secondPool = new ArrayCachePool();
+        $secondPool->save(new CacheItem($firstKey, true, $firstValue));
+        self::assertTrue($secondPool->hasItem($firstKey));
+    
+        $secondPool->save(new CacheItem($secondKey, true, $secondValue));
+        self::assertTrue($secondPool->hasItem($secondKey));
+    
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+    
+        self::assertTrue($chain->hasItem($firstKey));
+        self::assertTrue($chain->hasItem($secondKey));
+    
+        self::assertTrue($chain->deleteItems([
+            $firstKey,
+            $secondKey,
+        ]));
+    
+        self::assertFalse($chain->hasItem($firstKey));
+        self::assertFalse($chain->hasItem($secondKey));
+    }
+    
+    public function testDeferredSaveWritesOneItemToMultiplePools()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new ArrayCachePool();
+        self::assertFalse($firstPool->hasItem($key));
+        
+        $secondPool = new ArrayCachePool();
+        self::assertFalse($secondPool->hasItem($key));
+        
+        $chain = new CachePoolChain([
+            $firstPool,
+            $secondPool,
+        ]);
+    
+        self::assertTrue($chain->saveDeferred(new CacheItem($key, true, $value)));
+        
+        self::assertTrue($chain->hasItem($key));
+        self::assertTrue($firstPool->hasItem($key));
+        self::assertTrue($secondPool->hasItem($key));
+        
+        self::assertTrue($chain->commit());
+    
+        self::assertTrue($chain->hasItem($key));
+        self::assertTrue($firstPool->hasItem($key));
+        self::assertTrue($secondPool->hasItem($key));
     }
 }

--- a/src/Adapter/Chain/Tests/SimpleCacheChainTest.php
+++ b/src/Adapter/Chain/Tests/SimpleCacheChainTest.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace Cache\Adapter\Chain\Tests;
+
+use Cache\Adapter\Chain\SimpleCacheChain;
+use Cache\Adapter\PHPArray\SimpleArrayCache;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+/**
+ * @covers \Cache\Adapter\Chain\SimpleCacheChain
+ */
+class SimpleCacheChainTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWritesOneItemToMultiplePools()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+        
+        $secondPool = new SimpleArrayCache();
+        self::assertFalse($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $result = $chain->set($key, $value);
+        
+        self::assertTrue($result);
+        
+        self::assertTrue($firstPool->has($key));
+        self::assertTrue($secondPool->has($key));
+    }
+    
+    public function testReadsOneItemFromFirstPool()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+    
+        $firstPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($firstPool->has($key));
+        
+        $secondPool = new SimpleArrayCache();
+        self::assertFalse($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $result = $chain->get($key);
+        
+        self::assertSame($value, $result);
+    }
+    
+    public function testReadsOneItemFromSecondPool()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+    
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $result = $chain->get($key);
+        
+        self::assertSame($value, $result);
+    }
+    
+    public function testGetDefault()
+    {
+        $key = 'FooBar';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+    
+        $secondPool = new SimpleArrayCache();
+        self::assertFalse($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $default = new \Exception();
+        
+        $result = $chain->get($key, $default);
+        
+        self::assertSame($default, $result);
+    }
+    
+    /**
+     * @expectedException \Psr\Cache\CacheException
+     */
+    public function testDefaultBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = $this->getMockBuilder(CacheInterface::class)
+            ->getMock();
+        $firstPool->method('get')
+            ->with($key)
+            ->willThrowException(new InvalidArgumentException());
+    
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        $chain->get($key);
+    }
+    
+    /**
+     * @expectedException \Psr\Cache\CacheException
+     */
+    public function testDisabledBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = $this->getMockBuilder(CacheInterface::class)
+            ->getMock();
+        $firstPool->method('get')
+            ->with($key)
+            ->willThrowException(new InvalidArgumentException());
+    
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $pools = [
+            $firstPool,
+            $secondPool,
+        ];
+        
+        $options = [
+            'skip_on_failure' => false,
+        ];
+        
+        $chain = new SimpleCacheChain($pools, $options);
+        
+        $chain->get($key);
+    }
+    
+    public function testEnabledBehaviorOfSkipOnFailureOption()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = $this->getMockBuilder(CacheInterface::class)
+            ->getMock();
+        $firstPool->method('get')
+            ->with($key)
+            ->willThrowException(new InvalidArgumentException());
+        
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $pools = [
+            $firstPool,
+            $secondPool,
+        ];
+        
+        $options = [
+            'skip_on_failure' => true,
+        ];
+        
+        $chain = new SimpleCacheChain($pools, $options);
+        
+        $result = $chain->get($key);
+        
+        self::assertSame($value, $result);
+    }
+    
+    public function testReadsManyItems()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+        
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+        
+        $pool = new SimpleArrayCache([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+        self::assertTrue($pool->has($firstKey));
+        self::assertTrue($pool->has($secondKey));
+        
+        $chain = new SimpleCacheChain([
+            $pool,
+        ]);
+        
+        $values = $chain->getMultiple([
+            $firstKey,
+            $secondKey,
+        ]);
+        
+        self::assertSame($firstValue, $values[$firstKey]);
+        self::assertSame($secondValue, $values[$secondKey]);
+    }
+    
+    public function testReadsManyMissedItems()
+    {
+        $firstKey = 'FooBar';
+        $secondKey = 'FizBuz';
+    
+        $pool = new SimpleArrayCache();
+    
+        $chain = new SimpleCacheChain([
+            $pool,
+        ]);
+        
+        $values = $chain->getMultiple([
+            $firstKey,
+            $secondKey,
+        ]);
+        
+        self::assertNull($values[$firstKey]);
+        self::assertNull($values[$secondKey]);
+    }
+    
+    public function testHasItem()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+    
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertTrue($chain->has($key));
+    }
+    
+    public function testNotHasItem()
+    {
+        $key = 'FooBar';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+        
+        $secondPool = new SimpleArrayCache();
+        self::assertFalse($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertFalse($chain->has($key));
+    }
+    
+    public function testClear()
+    {
+        $key = 'FooBar';
+        $value = 'FizBuz';
+        
+        $firstPool = new SimpleArrayCache();
+        self::assertFalse($firstPool->has($key));
+    
+        $secondPool = new SimpleArrayCache([
+            $key => $value,
+        ]);
+        self::assertTrue($secondPool->has($key));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertTrue($chain->has($key));
+        
+        self::assertTrue($chain->clear());
+        
+        self::assertFalse($chain->has($key));
+    }
+    
+    public function testDeleteItem()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+        
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+        
+        $firstPool = new SimpleArrayCache([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+        self::assertTrue($firstPool->has($firstKey));
+        self::assertTrue($firstPool->has($secondKey));
+        
+        $secondPool = new SimpleArrayCache([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+        self::assertTrue($secondPool->has($firstKey));
+        self::assertTrue($secondPool->has($secondKey));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertTrue($chain->has($firstKey));
+        self::assertTrue($chain->has($secondKey));
+        
+        self::assertTrue($chain->delete($firstKey));
+        
+        self::assertFalse($chain->has($firstKey));
+        self::assertTrue($chain->has($secondKey));
+    }
+    
+    public function testDeleteItems()
+    {
+        $firstKey = 'FooBar';
+        $firstValue = 'FizBuz';
+        
+        $secondKey = 'Alice';
+        $secondValue = 'Bob';
+    
+        $firstPool = new SimpleArrayCache([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+        self::assertTrue($firstPool->has($firstKey));
+        self::assertTrue($firstPool->has($secondKey));
+    
+        $secondPool = new SimpleArrayCache([
+            $firstKey => $firstValue,
+            $secondKey => $secondValue,
+        ]);
+        self::assertTrue($secondPool->has($firstKey));
+        self::assertTrue($secondPool->has($secondKey));
+        
+        $chain = new SimpleCacheChain([
+            $firstPool,
+            $secondPool,
+        ]);
+        
+        self::assertTrue($chain->has($firstKey));
+        self::assertTrue($chain->has($secondKey));
+        
+        self::assertTrue($chain->deleteMultiple([
+            $firstKey,
+            $secondKey,
+        ]));
+        
+        self::assertFalse($chain->has($firstKey));
+        self::assertFalse($chain->has($secondKey));
+    }
+    
+    /**
+     * @expectedException \Cache\Adapter\Chain\Exception\NoPoolAvailableException
+     */
+    public function testNoPools()
+    {
+        new SimpleCacheChain([]);
+    }
+}

--- a/src/Adapter/PHPArray/SimpleArrayCache.php
+++ b/src/Adapter/PHPArray/SimpleArrayCache.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Cache\Adapter\PHPArray;
+
+use Psr\SimpleCache\CacheInterface;
+
+class SimpleArrayCache implements CacheInterface
+{
+    /** @var array */
+    private $cache;
+    
+    /**
+     * SimpleArrayCache constructor.
+     * @param array $cache
+     */
+    public function __construct(array $cache = [])
+    {
+        $this->cache = $cache;
+    }
+    
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key The unique key of this item in the cache.
+     * @param mixed $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function get($key, $default = null)
+    {
+        if ($this->has($key)) {
+            return $this->cache[$key];
+        }
+        
+        return $default;
+    }
+    
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string $key The key of the item to store.
+     * @param mixed $value The value of the item to store, must be serializable.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $this->cache[$key] = $value;
+        
+        return true;
+    }
+    
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function delete($key)
+    {
+        unset($this->cache[$key]);
+        
+        return true;
+    }
+    
+    /**
+     * Wipes clean the entire cache's keys.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function clear()
+    {
+        $this->cache = [];
+        
+        return true;
+    }
+    
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys A list of keys that can obtained in a single operation.
+     * @param mixed $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        $defaults = array_combine($keys, array_fill(0, count($keys), $default));
+        
+        return array_merge($defaults, $this->cache);
+    }
+    
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|\DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $values is neither an array nor a Traversable,
+     *   or if any of the $values are not a legal value.
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $this->cache = array_merge($this->cache, $values);
+        
+        return true;
+    }
+    
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if $keys is neither an array nor a Traversable,
+     *   or if any of the $keys are not a legal value.
+     */
+    public function deleteMultiple($keys)
+    {
+        $this->cache = array_diff_key(array_keys($this->cache), $keys);
+    
+        return true;
+    }
+    
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     *
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     *   MUST be thrown if the $key string is not a legal value.
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->cache);
+    }
+}

--- a/src/Adapter/PHPArray/Tests/SimpleArrayCacheTest.php
+++ b/src/Adapter/PHPArray/Tests/SimpleArrayCacheTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Cache\Adapter\PHPArray\Tests;
+
+use Cache\Adapter\PHPArray\SimpleArrayCache;
+
+/**
+ * @covers \Cache\Adapter\PHPArray\SimpleArrayCache
+ */
+class SimpleArrayCacheTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var SimpleArrayCache */
+    private $sut;
+    
+    protected function setUp()
+    {
+        $this->sut = new SimpleArrayCache();
+    }
+    
+    public function testGetValue()
+    {
+        self::assertTrue($this->sut->set('Fiz', 'Buz'));
+        
+        self::assertSame('Buz', $this->sut->get('Fiz'));
+    }
+    
+    public function testGetDefaultValue()
+    {
+        $default = new \Exception();
+        
+        self::assertSame($default, $this->sut->get('Fiz', $default));
+    }
+    
+    public function testSetValue()
+    {
+        self::assertFalse($this->sut->has('Fiz'));
+        
+        self::assertTrue($this->sut->set('Fiz', 'Buz'));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+    }
+    
+    public function testDeleteValue()
+    {
+        self::assertTrue($this->sut->set('Fiz', 'Buz'));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+    
+        self::assertTrue($this->sut->delete('Fiz'));
+        
+        self::assertFalse($this->sut->has('Fiz'));
+    }
+    
+    public function testClear()
+    {
+        self::assertTrue($this->sut->set('Fiz', 'Buz'));
+        self::assertTrue($this->sut->set('Foo', 'Bar'));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+        self::assertTrue($this->sut->has('Foo'));
+    
+        self::assertTrue($this->sut->clear());
+        
+        self::assertFalse($this->sut->has('Fiz'));
+        self::assertFalse($this->sut->has('Foo'));
+    }
+    
+    public function testGetMultiple()
+    {
+        self::assertTrue($this->sut->set('Fiz', 'Buz'));
+        self::assertTrue($this->sut->set('Foo', 'Bar'));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+        self::assertTrue($this->sut->has('Foo'));
+        
+        $actual = $this->sut->getMultiple([
+            'Fiz',
+            'Foo',
+        ]);
+        
+        $expected = [
+            'Fiz' => 'Buz',
+            'Foo' => 'Bar',
+        ];
+        
+        self::assertArraySubset($expected, $actual);
+    }
+    
+    public function testGetMultipleSubset()
+    {
+        self::assertTrue($this->sut->set('Foo', 'Bar'));
+        
+        self::assertFalse($this->sut->has('Fiz'));
+        self::assertTrue($this->sut->has('Foo'));
+        
+        $actual = $this->sut->getMultiple([
+            'Fiz',
+            'Foo',
+        ]);
+        
+        $expected = [
+            'Fiz' => null,
+            'Foo' => 'Bar',
+        ];
+        
+        self::assertArraySubset($expected, $actual);
+    }
+    
+    public function testSetMultiple()
+    {
+        self::assertFalse($this->sut->has('Fiz'));
+        self::assertFalse($this->sut->has('Foo'));
+        
+        self::assertTrue($this->sut->setMultiple([
+            'Fiz' => 'Buz',
+            'Foo' => 'Bar',
+        ]));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+        self::assertTrue($this->sut->has('Foo'));
+    }
+    
+    public function testDeleteMultiple()
+    {
+        self::assertFalse($this->sut->has('Fiz'));
+        self::assertFalse($this->sut->has('Foo'));
+        
+        self::assertTrue($this->sut->setMultiple([
+            'Fiz' => 'Buz',
+            'Foo' => 'Bar',
+        ]));
+        
+        self::assertTrue($this->sut->has('Fiz'));
+        self::assertTrue($this->sut->has('Foo'));
+        
+        self::assertTrue($this->sut->deleteMultiple([
+            'Fiz',
+            'Foo',
+        ]));
+        
+        self::assertFalse($this->sut->has('Fiz'));
+        self::assertFalse($this->sut->has('Foo'));
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

hi Team,

thank you for a wonderfully useful library!

this request:
* adds SimpleCacheChain which implements PSR-16 and mimics the CachePoolChain implementation of PSR-6, except that SimpleCacheChain cannot restore hits later in the chain to pools earlier in the chain because TTL is not known.
* adds SimpleArrayCache which implements PSR-16.
* adds unit tests to cover CachePoolChain, SimpleCacheChain, and SimpleArrayCache. SimpleCacheChainTest uses SimpleArrayCache as a dummy pool.

neither of these new PSR-16 pools implement Taggable, nor do they descend from a common ancestor. i imagine you might require one or both of these as entry criteria, but i wanted to float this idea past you before i put much more time into it.

thoughts?

oh, i see now that a resolved conflict resulted in unintended formatting changes in CachePoolChainTest. i will undo those changes : )

### TODO
* [x] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
