### PR TITLE
Fix missing tag warning error

### DIFF
--- a/src/Adapter/PHPArray/ArrayCachePool.php
+++ b/src/Adapter/PHPArray/ArrayCachePool.php
@@ -197,9 +197,11 @@ class ArrayCachePool extends AbstractCachePool implements HierarchicalPoolInterf
      */
     protected function removeListItem($name, $key)
     {
-        foreach ($this->cache[$name] as $i => $item) {
-            if ($item === $key) {
-                unset($this->cache[$name][$i]);
+        if (isset($this->cache[$name])) {
+            foreach ($this->cache[$name] as $i => $item) {
+                if ($item === $key) {
+                    unset($this->cache[$name][$i]);
+                }
             }
         }
     }

--- a/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
+++ b/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
@@ -52,9 +52,9 @@ class ArrayCachePoolTest extends \PHPUnit_Framework_TestCase
 
     public function testRemoveListItem()
     {
-        $pool = new ArrayCachePool();
+        $pool       = new ArrayCachePool();
         $reflection = new \ReflectionClass(get_class($pool));
-        $method = $reflection->getMethod('removeListItem');
+        $method     = $reflection->getMethod('removeListItem');
         $method->setAccessible(true);
 
         // Add a tagged item to test list removal

--- a/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
+++ b/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
@@ -49,4 +49,24 @@ class ArrayCachePoolTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($pool->hasItem('key3'));
         $this->assertTrue($pool->hasItem('key4'));
     }
+
+    public function testRemoveListItem()
+    {
+        $pool = new ArrayCachePool();
+        $reflection = new \ReflectionClass(get_class($pool));
+        $method = $reflection->getMethod('removeListItem');
+        $method->setAccessible(true);
+
+        // Add a tagged item to test list removal
+        $item = $pool->getItem('key1')->set('value1')->setTags(['tag1']);
+        $pool->save($item);
+
+        $this->assertTrue($pool->hasItem('key1'));
+        $this->assertTrue($pool->deleteItem('key1'));
+        $this->assertFalse($pool->hasItem('key1'));
+
+        // Trying to remove an item in an un-existing tag list should not throw
+        // Notice error / Exception in strict mode
+        $this->assertNull($method->invokeArgs($pool, ['tag1', 'key1']));
+    }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description
I'm using the Symfony bundle with this configuration:

```
cache_adapter:
  providers:
    api_redis1:
      factory: 'cache.factory.predis'
      options:
        dsn: "%redis_dsn%"
        pool_namespace: "%mall_reference%_website"
      aliases: ['cache.api_redis1']
    api_redis2:
      factory: 'cache.factory.predis'
      options:
        dsn: "%redis2_dsn%"
        pool_namespace: "%mall_reference%_website"
      aliases: ['cache.api_redis2']
    api_array:
      factory: "cache.factory.array"
      options:
        pool_namespace: "%mall_reference%_website"
      aliases: ["cache.api_array"]
    api:
      factory: "cache.factory.chain"
      options:
        services:
          - '@cache.api_array'
          - '@cache.api_redis1'
          - '@cache.api_redis2'
        skip_on_failure: true
      aliases: ["cache.api"]
```

When the redis cache is available, I get those errors

```
( ! ) Notice: Undefined index: tag!page in vendor/cache/array-adapter/ArrayCachePool.php on line 200
--
1 | 0.0002 | 250272 | {main}(  ) | .../app.php:0
2 | 0.0779 | 1756040 | Symfony\Component\HttpKernel\Kernel->handle(  ) | .../app.php:18
3 | 0.3354 | 5658032 | Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle(  ) | .../bootstrap.php.cache:1505
4 | 0.3355 | 5659288 | Symfony\Component\HttpKernel\HttpKernel->handle(  ) | .../ContainerAwareHttpKernel.php:69
5 | 0.3355 | 5660240 | Symfony\Component\HttpKernel\HttpKernel->handleRaw(  ) | .../HttpKernel.php:64
6 | 0.5733 | 8108848 | call_user_func_array:{vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:144} (  ) | .../HttpKernel.php:144
7 | 0.5733 | 8109728 | AppBundle\Controller\DefaultController->indexAction(  ) | .../HttpKernel.php:144
8 | 0.7872 | 10893728 | AppBundle\Provider\ContentProvider->getStructBySlug(  ) | .../DefaultController.php:143
9 | 0.7872 | 10894512 | AppBundle\Provider\ContentProvider->getApiData(  ) | .../ContentProvider.php:176
10 | 0.7872 | 10894760 | Cache\Adapter\Chain\CachePoolChain->getItem(  ) | .../ContentProvider.php:219
11 | 0.8431 | 11034816 | Cache\Namespaced\NamespacedCachePool->save(  ) | .../CachePoolChain.php:89
12 | 0.8431 | 11035008 | Cache\Adapter\Common\AbstractCachePool->save(  ) | .../NamespacedCachePool.php:129
13 | 0.8431 | 11035088 | Cache\Adapter\Common\AbstractCachePool->removeTagEntries(  ) | .../AbstractCachePool.php:228
14 | 0.8431 | 11036072 | Cache\Adapter\PHPArray\ArrayCachePool->removeListItem(  ) | .../AbstractCachePool.php:409


( ! )  Warning: Invalid argument supplied for foreach() in vendor/cache/array-adapter/ArrayCachePool.php  on line 200
--
1 | 0.0002 | 250272 | {main}(  ) | .../app.php:0
2 | 0.0779 | 1756040 | Symfony\Component\HttpKernel\Kernel->handle(  ) | .../app.php:18
3 | 0.3354 | 5658032 | Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle(  ) | .../bootstrap.php.cache:1505
4 | 0.3355 | 5659288 | Symfony\Component\HttpKernel\HttpKernel->handle(  ) | .../ContainerAwareHttpKernel.php:69
5 | 0.3355 | 5660240 | Symfony\Component\HttpKernel\HttpKernel->handleRaw(  ) | .../HttpKernel.php:64
6 | 0.5733 | 8108848 | call_user_func_array:{vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:144} (  ) | .../HttpKernel.php:144
7 | 0.5733 | 8109728 | AppBundle\Controller\DefaultController->indexAction(  ) | .../HttpKernel.php:144
8 | 0.7872 | 10893728 | AppBundle\Provider\ContentProvider->getStructBySlug(  ) | .../DefaultController.php:143
9 | 0.7872 | 10894512 | AppBundle\Provider\ContentProvider->getApiData(  ) | .../ContentProvider.php:176
10 | 0.7872 | 10894760 | Cache\Adapter\Chain\CachePoolChain->getItem(  ) | .../ContentProvider.php:219
11 | 0.8431 | 11034816 | Cache\Namespaced\NamespacedCachePool->save(  ) | .../CachePoolChain.php:89
12 | 0.8431 | 11035008 | Cache\Adapter\Common\AbstractCachePool->save(  ) | .../NamespacedCachePool.php:129
13 | 0.8431 | 11035088 | Cache\Adapter\Common\AbstractCachePool->removeTagEntries(  ) | .../AbstractCachePool.php:228
14 | 0.8431 | 11036072 | Cache\Adapter\PHPArray\ArrayCachePool->removeListItem(  ) | .../AbstractCachePool.php:409
```