### PR TITLE
Update to use interface instead of concreate class

### DIFF
--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -37,7 +37,7 @@ class FilesystemCachePool extends AbstractCachePool
 
     /**
      * @param FilesystemInterface $filesystem
-     * @param string     $folder
+     * @param string              $folder
      */
     public function __construct(FilesystemInterface $filesystem, $folder = 'cache')
     {

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -16,7 +16,7 @@ use Cache\Adapter\Common\Exception\InvalidArgumentException;
 use Cache\Adapter\Common\PhpCacheItem;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
-use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -24,7 +24,7 @@ use League\Flysystem\Filesystem;
 class FilesystemCachePool extends AbstractCachePool
 {
     /**
-     * @type Filesystem
+     * @type FilesystemInterface
      */
     private $filesystem;
 
@@ -36,10 +36,10 @@ class FilesystemCachePool extends AbstractCachePool
     private $folder;
 
     /**
-     * @param Filesystem $filesystem
+     * @param FilesystemInterface $filesystem
      * @param string     $folder
      */
-    public function __construct(Filesystem $filesystem, $folder = 'cache')
+    public function __construct(FilesystemInterface $filesystem, $folder = 'cache')
     {
         $this->folder = $folder;
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | No
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

### Description
Switch from using the concrete  class of `League\Flysystem\Filesystem` to the interface of `League\Flysystem\FilesystemInterface`
