### PR TITLE
[WIP] Handle unserialize() failures gracefully

### DIFF
--- a/src/Adapter/Apc/ApcCachePool.php
+++ b/src/Adapter/Apc/ApcCachePool.php
@@ -44,12 +44,18 @@ class ApcCachePool extends AbstractCachePool
             return [false, null, [], null];
         }
 
-        $success   = false;
-        $cacheData = apc_fetch($key, $success);
+        $success = false;
+
+        try {
+            $cacheData = apc_fetch($key, $success);
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        }
+
         if (!$success) {
             return [false, null, [], null];
         }
-        list($data, $tags, $timestamp) = unserialize($cacheData);
+        list($data, $tags, $timestamp) = parent::unserialize($cacheData);
 
         return [$success, $data, $tags, $timestamp];
     }

--- a/src/Adapter/Apc/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Apc/Tests/IntegrationPoolTest.php
@@ -12,10 +12,13 @@
 namespace Cache\Adapter\Apc\Tests;
 
 use Cache\Adapter\Apc\ApcCachePool;
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest as BaseTest;
 
 class IntegrationPoolTest extends BaseTest
 {
+    use TestNotUnserializableTrait;
+
     protected $skippedTests = [
         'testExpiration'      => 'The cache expire at the next request.',
         'testSaveExpired'     => 'The cache expire at the next request.',

--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -44,12 +44,18 @@ class ApcuCachePool extends AbstractCachePool
             return [false, null, [], null];
         }
 
-        $success   = false;
-        $cacheData = apcu_fetch($key, $success);
+        $success = false;
+
+        try {
+            $cacheData = apcu_fetch($key, $success);
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        }
+
         if (!$success) {
             return [false, null, [], null];
         }
-        list($data, $tags, $timestamp) = unserialize($cacheData);
+        list($data, $tags, $timestamp) = parent::unserialize($cacheData);
 
         return [$success, $data, $tags, $timestamp];
     }

--- a/src/Adapter/Apcu/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Apcu/Tests/IntegrationPoolTest.php
@@ -12,10 +12,13 @@
 namespace Cache\Adapter\Apcu\Tests;
 
 use Cache\Adapter\Apcu\ApcuCachePool;
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest as BaseTest;
 
 class IntegrationPoolTest extends BaseTest
 {
+    use TestNotUnserializableTrait;
+
     protected $skippedTests = [
         'testExpiration'      => 'The cache expire at the next request.',
         'testSaveExpired'     => 'The cache expire at the next request.',

--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -333,6 +333,7 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
         }
 
         $this->log($level, $e->getMessage(), ['exception' => $e]);
+
         if (!$e instanceof CacheException) {
             $e = new CachePoolException(sprintf('Exception thrown when executing "%s". ', $function), 0, $e);
         }
@@ -554,5 +555,47 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
     public function has($key)
     {
         return $this->hasItem($key);
+    }
+
+    /**
+     * Like the native unserialize() function but throws an exception if anything goes wrong.
+     *
+     * @param string $value
+     *
+     * @throws \Exception
+     *
+     * @return mixed
+     */
+    protected static function unserialize($value)
+    {
+        if ('b:0;' === $value) {
+            return false;
+        }
+
+        $unserializeCallbackHandler = \ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
+
+        try {
+            if (false !== $value = \unserialize($value)) {
+                return $value;
+            }
+
+            throw new \DomainException('Failed to unserialize cached value');
+        } catch (\Error $e) {
+            throw new \ErrorException($e->getMessage(), $e->getCode(), E_ERROR, $e->getFile(), $e->getLine());
+        } finally {
+            \ini_set('unserialize_callback_func', $unserializeCallbackHandler);
+        }
+    }
+
+    /**
+     * @internal
+     *
+     * @param string $class
+     *
+     * @throws \DomainException
+     */
+    public static function handleUnserializeCallback($class)
+    {
+        throw new \DomainException('Class not found: '.$class);
     }
 }

--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -62,6 +62,7 @@ class CacheItem implements PhpCacheItem
     /**
      * @param string        $key
      * @param \Closure|bool $callable or boolean hasValue
+     * @param mixed         $value
      */
     public function __construct($key, $callable = null, $value = null)
     {
@@ -241,8 +242,14 @@ class CacheItem implements PhpCacheItem
     {
         if ($this->callable !== null) {
             // $func will be $adapter->fetchObjectFromCache();
-            $func                      = $this->callable;
-            $result                    = $func();
+            $func = $this->callable;
+
+            try {
+                $result = $func();
+            } catch (\DomainException $exception) {
+                return;
+            }
+
             $this->hasValue            = $result[0];
             $this->value               = $result[1];
             $this->prevTags            = isset($result[2]) ? $result[2] : [];

--- a/src/Adapter/Common/Tests/Fixture/NotUnserializable.php
+++ b/src/Adapter/Common/Tests/Fixture/NotUnserializable.php
@@ -9,13 +9,17 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Cache\Adapter\Doctrine\Tests;
+namespace Cache\Adapter\Common\Tests\Fixture;
 
-use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
-use Cache\IntegrationTests\CachePoolTest;
-
-class IntegrationPoolTest extends CachePoolTest
+class NotUnserializable implements \Serializable
 {
-    use CreatePoolTrait;
-    use TestNotUnserializableTrait;
+    public function serialize()
+    {
+        return serialize(123);
+    }
+
+    public function unserialize($ser)
+    {
+        throw new \Exception(__CLASS__);
+    }
 }

--- a/src/Adapter/Common/Tests/Traits/TestNotUnserializableTrait.php
+++ b/src/Adapter/Common/Tests/Traits/TestNotUnserializableTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of php-cache organization.
+ *
+ * (c) 2015 Aaron Scherer <aequasi@gmail.com>, Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Cache\Adapter\Common\Tests\Traits;
+
+use Cache\Adapter\Common\Tests\Fixture\NotUnserializable;
+use Psr\Cache\CacheItemPoolInterface;
+
+trait TestNotUnserializableTrait
+{
+    public function testNotUnserializable()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set(new NotUnserializable()));
+
+        $item = $cache->getItem('foo');
+        $this->assertFalse($item->isHit());
+
+        foreach ($cache->getItems(['foo']) as $item) {
+        }
+
+        $cache->save($item->set(new NotUnserializable()));
+
+        foreach ($cache->getItems(['foo']) as $item) {
+        }
+
+        $this->assertFalse($item->isHit());
+    }
+
+    /**
+     * @return CacheItemPoolInterface that is used in the tests
+     */
+    abstract public function createCachePool();
+}

--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -64,7 +64,7 @@ class FilesystemCachePool extends AbstractCachePool
         $file  = $this->getFilePath($key);
 
         try {
-            $data = @unserialize($this->filesystem->read($file));
+            $data = parent::unserialize($this->filesystem->read($file));
             if ($data === false) {
                 return $empty;
             }
@@ -159,7 +159,7 @@ class FilesystemCachePool extends AbstractCachePool
             $this->filesystem->write($file, serialize([]));
         }
 
-        return unserialize($this->filesystem->read($file));
+        return parent::unserialize($this->filesystem->read($file));
     }
 
     /**

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -11,6 +11,8 @@
 
 namespace Cache\Adapter\Filesystem\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 class FilesystemCachePoolTest extends TestCase
 {
     use CreatePoolTrait;
+    use TestNotUnserializableTrait;
 
     /**
      * @expectedException \Psr\Cache\InvalidArgumentException

--- a/src/Adapter/Illuminate/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Illuminate/Tests/IntegrationPoolTest.php
@@ -11,9 +11,11 @@
 
 namespace Cache\Adapter\Illuminate\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest;
 
 class IntegrationPoolTest extends CachePoolTest
 {
     use CreatePoolTrait;
+    use TestNotUnserializableTrait;
 }

--- a/src/Adapter/Memcache/MemcacheCachePool.php
+++ b/src/Adapter/Memcache/MemcacheCachePool.php
@@ -38,7 +38,7 @@ class MemcacheCachePool extends AbstractCachePool
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($key))) {
+        if (false === $result = parent::unserialize($this->cache->get($key))) {
             return [false, null, [], null];
         }
 

--- a/src/Adapter/Memcache/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Memcache/Tests/IntegrationPoolTest.php
@@ -11,12 +11,15 @@
 
 namespace Cache\Adapter\Memcache\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\Adapter\Memcache\MemcacheCachePool;
 use Cache\IntegrationTests\CachePoolTest;
 use Memcache;
 
 class IntegrationPoolTest extends CachePoolTest
 {
+    use TestNotUnserializableTrait;
+
     private $client;
 
     public function createCachePool()

--- a/src/Adapter/Memcached/MemcachedCachePool.php
+++ b/src/Adapter/Memcached/MemcachedCachePool.php
@@ -45,7 +45,7 @@ class MemcachedCachePool extends AbstractCachePool implements HierarchicalPoolIn
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
+        if (false === $result = parent::unserialize($this->cache->get($this->getHierarchyKey($key)))) {
             return [false, null, [], null];
         }
 

--- a/src/Adapter/Memcached/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Memcached/Tests/IntegrationPoolTest.php
@@ -11,9 +11,11 @@
 
 namespace Cache\Adapter\Memcached\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest as BaseTest;
 
 class IntegrationPoolTest extends BaseTest
 {
     use CreatePoolTrait;
+    use TestNotUnserializableTrait;
 }

--- a/src/Adapter/MongoDB/MongoDBCachePool.php
+++ b/src/Adapter/MongoDB/MongoDBCachePool.php
@@ -149,11 +149,11 @@ class MongoDBCachePool extends AbstractCachePool
 
     private function freezeValue($value)
     {
-        return static::jsonArmor(serialize($value));
+        return static::jsonArmor(parent::serialize($value));
     }
 
     private function thawValue($value)
     {
-        return unserialize(static::jsonDeArmor($value));
+        return parent::unserialize(static::jsonDeArmor($value));
     }
 }

--- a/src/Adapter/MongoDB/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/MongoDB/Tests/IntegrationPoolTest.php
@@ -11,12 +11,14 @@
 
 namespace Cache\Adapter\MongoDB\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\Adapter\MongoDB\MongoDBCachePool;
 use Cache\IntegrationTests\CachePoolTest;
 
 class IntegrationPoolTest extends CachePoolTest
 {
     use CreateServerTrait;
+    use TestNotUnserializableTrait;
 
     public function createCachePool()
     {

--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -42,7 +42,7 @@ class PredisCachePool extends AbstractCachePool implements HierarchicalPoolInter
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
+        if (false === $result = parent::unserialize($this->cache->get($this->getHierarchyKey($key)))) {
             return [false, null, [], null];
         }
 

--- a/src/Adapter/Predis/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Predis/Tests/IntegrationPoolTest.php
@@ -11,9 +11,11 @@
 
 namespace Cache\Adapter\Predis\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest;
 
 class IntegrationPoolTest extends CachePoolTest
 {
     use CreatePoolTrait;
+    use TestNotUnserializableTrait;
 }

--- a/src/Adapter/Redis/RedisCachePool.php
+++ b/src/Adapter/Redis/RedisCachePool.php
@@ -51,7 +51,7 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
+        if (false === $result = parent::unserialize($this->cache->get($this->getHierarchyKey($key)))) {
             return [false, null, [], null];
         }
 

--- a/src/Adapter/Redis/Tests/IntegrationPoolTest.php
+++ b/src/Adapter/Redis/Tests/IntegrationPoolTest.php
@@ -11,9 +11,11 @@
 
 namespace Cache\Adapter\Redis\Tests;
 
+use Cache\Adapter\Common\Tests\Traits\TestNotUnserializableTrait;
 use Cache\IntegrationTests\CachePoolTest as BaseTest;
 
 class IntegrationPoolTest extends BaseTest
 {
     use CreateRedisPoolTrait;
+    use TestNotUnserializableTrait;
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | php-cache/issues/issues/65
| License       | MIT

### Description
errors triggered by unserialize should be turned to cache misses.


### TODO
* [x] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
