### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/src/Adapter/Chain/Tests/CachePoolChainTest.php
+++ b/src/Adapter/Chain/Tests/CachePoolChainTest.php
@@ -14,11 +14,12 @@ namespace Cache\Adapter\Chain\Tests;
 use Cache\Adapter\Chain\CachePoolChain;
 use Cache\Adapter\Common\CacheItem;
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ChainPoolTest.
  */
-class CachePoolChainTest extends \PHPUnit_Framework_TestCase
+class CachePoolChainTest extends TestCase
 {
     public function testGetItemStoreToPrevious()
     {

--- a/src/Adapter/Common/Tests/CacheItemTest.php
+++ b/src/Adapter/Common/Tests/CacheItemTest.php
@@ -12,9 +12,10 @@
 namespace Cache\Adapter\Common\Tests;
 
 use Cache\Adapter\Common\CacheItem;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 
-class CacheItemTest extends \PHPUnit_Framework_TestCase
+class CacheItemTest extends TestCase
 {
     public function testConstructor()
     {

--- a/src/Adapter/Doctrine/Tests/DoctrineAdapterTest.php
+++ b/src/Adapter/Doctrine/Tests/DoctrineAdapterTest.php
@@ -17,12 +17,13 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\FlushableCache;
 use Mockery as m;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
  */
-class DoctrineAdapterTest extends \PHPUnit_Framework_TestCase
+class DoctrineAdapterTest extends TestCase
 {
     /**
      * @type DoctrineCachePool

--- a/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
+++ b/src/Adapter/Filesystem/Tests/FilesystemCachePoolTest.php
@@ -11,10 +11,12 @@
 
 namespace Cache\Adapter\Filesystem\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class FilesystemCachePoolTest extends \PHPUnit_Framework_TestCase
+class FilesystemCachePoolTest extends TestCase
 {
     use CreatePoolTrait;
 

--- a/src/Adapter/Illuminate/Tests/IlluminateAdapterTest.php
+++ b/src/Adapter/Illuminate/Tests/IlluminateAdapterTest.php
@@ -16,9 +16,10 @@ use Cache\Adapter\Illuminate\IlluminateCachePool;
 use Illuminate\Contracts\Cache\Store;
 use Mockery as m;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
-class IlluminateAdapterTest extends \PHPUnit_Framework_TestCase
+class IlluminateAdapterTest extends TestCase
 {
     /**
      * @type IlluminateCachePool

--- a/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
+++ b/src/Adapter/Memcached/Tests/MemcachedCachePoolTest.php
@@ -11,7 +11,9 @@
 
 namespace Cache\Adapter\Memcached\Tests;
 
-class MemcachedCachePoolTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MemcachedCachePoolTest extends TestCase
 {
     use CreatePoolTrait;
 

--- a/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
+++ b/src/Adapter/PHPArray/Tests/ArrayCachePoolTest.php
@@ -12,8 +12,9 @@
 namespace Cache\Adapter\PHPArray\Tests;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use PHPUnit\Framework\TestCase;
 
-class ArrayCachePoolTest extends \PHPUnit_Framework_TestCase
+class ArrayCachePoolTest extends TestCase
 {
     public function testLimit()
     {

--- a/src/Bridge/Doctrine/Tests/DoctrineCacheBridgeTest.php
+++ b/src/Bridge/Doctrine/Tests/DoctrineCacheBridgeTest.php
@@ -13,13 +13,14 @@ namespace Cache\Bridge\Doctrine\Tests;
 
 use Cache\Bridge\Doctrine\DoctrineCacheBridge;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @author Aaron Scherer <aequasi@gmail.com>
  */
-class DoctrineCacheBridgeTest extends \PHPUnit_Framework_TestCase
+class DoctrineCacheBridgeTest extends TestCase
 {
     /**
      * @type DoctrineCacheBridge

--- a/src/Bridge/SimpleCache/Tests/SimpleCacheBridgeTest.php
+++ b/src/Bridge/SimpleCache/Tests/SimpleCacheBridgeTest.php
@@ -13,10 +13,11 @@ namespace Cache\Bridge\SimpleCache\Tests;
 
 use Cache\Bridge\SimpleCache\SimpleCacheBridge;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
-class SimpleCacheBridgeTest extends \PHPUnit_Framework_TestCase
+class SimpleCacheBridgeTest extends TestCase
 {
     /**
      * @type SimpleCacheBridge

--- a/src/Hierarchy/Tests/HierarchicalCachePoolTest.php
+++ b/src/Hierarchy/Tests/HierarchicalCachePoolTest.php
@@ -12,13 +12,14 @@
 namespace Cache\Hierarchy\Tests;
 
 use Cache\Hierarchy\Tests\Helper\CachePool;
+use PHPUnit\Framework\TestCase;
 
 /**
  * We should not use constants on interfaces in the tests. Tests should break if the constant is changed.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class HierarchicalCachePoolTest extends \PHPUnit_Framework_TestCase
+class HierarchicalCachePoolTest extends TestCase
 {
     private function assertEqualsSha1($expected, $result, $message = '')
     {

--- a/src/Namespaced/Tests/IntegrationTest.php
+++ b/src/Namespaced/Tests/IntegrationTest.php
@@ -15,12 +15,13 @@ use Cache\Adapter\Memcached\MemcachedCachePool;
 use Cache\Hierarchy\HierarchicalPoolInterface;
 use Cache\Namespaced\NamespacedCachePool;
 use Memcached;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends TestCase
 {
     /**
      * @type CacheItemPoolInterface|HierarchicalPoolInterface

--- a/src/Namespaced/Tests/NamespacedCachePoolTest.php
+++ b/src/Namespaced/Tests/NamespacedCachePoolTest.php
@@ -12,6 +12,7 @@
 namespace Cache\Namespaced\Tests;
 
 use Cache\Namespaced\NamespacedCachePool;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 
 /**
@@ -19,7 +20,7 @@ use Psr\Cache\CacheItemInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class NamespacedCachePoolTest extends \PHPUnit_Framework_TestCase
+class NamespacedCachePoolTest extends TestCase
 {
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject

--- a/src/Prefixed/Tests/PrefixedCachePoolTest.php
+++ b/src/Prefixed/Tests/PrefixedCachePoolTest.php
@@ -12,13 +12,14 @@
 namespace Cache\Prefixed\Tests;
 
 use Cache\Prefixed\PrefixedCachePool;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class PrefixedCachePoolTest extends \PHPUnit_Framework_TestCase
+class PrefixedCachePoolTest extends TestCase
 {
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|CacheItemPoolInterface

--- a/src/Prefixed/Tests/PrefixedSimpleCacheTest.php
+++ b/src/Prefixed/Tests/PrefixedSimpleCacheTest.php
@@ -12,6 +12,7 @@
 namespace Cache\Prefixed\Tests;
 
 use Cache\Prefixed\PrefixedSimpleCache;
+use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 
 /**
@@ -19,7 +20,7 @@ use Psr\SimpleCache\CacheInterface;
  *
  * @author ndobromirov
  */
-class PrefixedSimpleCacheTest extends \PHPUnit_Framework_TestCase
+class PrefixedSimpleCacheTest extends TestCase
 {
     /**
      * @param string $method    Method name to mock.

--- a/src/SessionHandler/Tests/Psr6SessionHandlerTest.php
+++ b/src/SessionHandler/Tests/Psr6SessionHandlerTest.php
@@ -13,6 +13,7 @@ namespace Cache\SessionHandler\Tests;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\SessionHandler\Psr6SessionHandler;
+use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -20,7 +21,7 @@ use Psr\Cache\CacheItemPoolInterface;
  * @author Aaron Scherer <aequasi@gmail.com>
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class Psr6SessionHandlerTest extends \PHPUnit_Framework_TestCase
+class Psr6SessionHandlerTest extends TestCase
 {
     const TTL    = 100;
     const PREFIX = 'pre';


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

### Description

I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

### TODO
* [x] Add tests
* [x] Add documentation
* [ ] Updated Changelog.md
