### PR TITLE
Handle PHP-bug with single char vars

### DIFF
--- a/src/Adapter/Common/CacheItem.php
+++ b/src/Adapter/Common/CacheItem.php
@@ -240,9 +240,9 @@ class CacheItem implements PhpCacheItem
     private function initialize()
     {
         if ($this->callable !== null) {
-            // $f will be $adapter->fetchObjectFromCache();
-            $f                         = $this->callable;
-            $result                    = $f();
+            // $func will be $adapter->fetchObjectFromCache();
+            $func                      = $this->callable;
+            $result                    = $func();
             $this->hasValue            = $result[0];
             $this->value               = $result[1];
             $this->prevTags            = isset($result[2]) ? $result[2] : [];


### PR DESCRIPTION
We encounter an issue with single-char PHP vars in production (running on amphp/aerys). We observe regularly, that single-char-vars become undefined. After PHP restart everything is ok again. The bug definitely exists in 7.1.9 + 7.1.11
Fixing that bug is hard, a workaround is simple and does not harm.

Thanks!

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

### Description



### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
