### PR TITLE
Run test on php7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       - php: 7.0
         env: COVERAGE=true
       - php: 7.1
+      - php: 7.2
       - php: 5.6
 
 services:

--- a/build/php/7.2/Apcu.sh
+++ b/build/php/7.2/Apcu.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Add php.ini settings"
+phpenv config-add ./build/php/apc.ini
+
+echo "Install APCu Adapter dependencies"
+yes '' | pecl install -f apcu-5.1.8

--- a/build/php/7.2/Memcached.sh
+++ b/build/php/7.2/Memcached.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Install memcache(d)"
+echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini

--- a/build/php/7.2/MongoDB.sh
+++ b/build/php/7.2/MongoDB.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Install MongoDB"
+pecl install -f mongodb-1.1.2

--- a/build/php/7.2/Redis.sh
+++ b/build/php/7.2/Redis.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Install redis"
+yes '' | pecl install -f redis-3.0.0


### PR DESCRIPTION
This will close #209 

@prisis I updated to run test on Trusty in #221. After that it was way simpler to enable PHP 7.2. 