### PR TITLE
Open pool for extension

### DIFF
--- a/src/Taggable/Changelog.md
+++ b/src/Taggable/Changelog.md
@@ -3,7 +3,9 @@
 The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
 
 ## UNRELEASED
-
+###Changed
+* Use late static binding when creating a new instance
+* Allow access to the pools
 ## 1.0.0
 
 ### Added

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -42,12 +42,12 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
     /**
      * @type CacheItemPoolInterface
      */
-    private $cachePool;
+    protected $cachePool;
 
     /**
      * @type CacheItemPoolInterface
      */
-    private $tagStorePool;
+    protected $tagStorePool;
 
     /**
      * @param CacheItemPoolInterface $cachePool
@@ -303,21 +303,5 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
         foreach ($tags as $tag) {
             $this->removeListItem($this->getTagKey($tag), $item->getKey());
         }
-    }
-
-    /**
-     * @return CacheItemPoolInterface
-     */
-    protected function getCachePool()
-    {
-        return $this->cachePool;
-    }
-
-    /**
-     * @return CacheItemPoolInterface
-     */
-    protected function getTagStorePool()
-    {
-        return $this->tagStorePool;
     }
 }

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -75,7 +75,7 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
             return $cachePool;
         }
 
-        return new self($cachePool, $tagStorePool);
+        return new static($cachePool, $tagStorePool);
     }
 
     /**

--- a/src/Taggable/TaggablePSR6PoolAdapter.php
+++ b/src/Taggable/TaggablePSR6PoolAdapter.php
@@ -304,4 +304,20 @@ class TaggablePSR6PoolAdapter implements TaggableCacheItemPoolInterface
             $this->removeListItem($this->getTagKey($tag), $item->getKey());
         }
     }
+
+    /**
+     * @return CacheItemPoolInterface
+     */
+    protected function getCachePool()
+    {
+        return $this->cachePool;
+    }
+
+    /**
+     * @return CacheItemPoolInterface
+     */
+    protected function getTagStorePool()
+    {
+        return $this->tagStorePool;
+    }
 }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| New feature?  | yes
| License       | MIT

### Description
I need to open the adapter for extension because I would like to override the methods that works with lists. 
Real life scenario: I use Memcached as a cachePool and Redis as a tagStorePool. Right now when I append a key to a list it gets the list, appends the element to list and than saves the list. If I override appendListItem, removeListItem and use the native functionality of redis for working with lists it will be three times faster. 


