### PR TITLE
Fix version number in PHPArray adapter Changelog

### DIFF
--- a/src/Adapter/PHPArray/Changelog.md
+++ b/src/Adapter/PHPArray/Changelog.md
@@ -8,7 +8,7 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 * New Hierarchical mode by using nested arrays instead of a flat array
 
-## 1.1.0
+## 1.0.1
 
 ### Fixed
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

### Description

There's no such version as 1.1.0. It's https://github.com/php-cache/array-adapter/releases/tag/1.0.1
