### PR TITLE
FilesystemCachePool: Getters/setters added for folder and filesystem

### DIFF
--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -41,10 +41,32 @@ class FilesystemCachePool extends AbstractCachePool
      */
     public function __construct(FilesystemInterface $filesystem, $folder = 'cache')
     {
-        $this->folder = $folder;
+        $this->setFolder($folder);
+        $this->setFilesystem($filesystem);
+        $this->getFilesystem()->createDir($this->getFolder());
+    }
 
+    /**
+     * Get folder
+     * @return string
+     */
+    public function getFolder()
+    {
+        return $this->folder;
+    }
+
+    /**
+     * Get Filesystem (Flysystem)
+     * @return \League\Flysystem\FilesystemInterface
+     */
+    public function getFilesystem()
+    {
+        return $this->filesystem;
+    }
+
+    public function setFilesystem(FilesystemInterface $filesystem)
+    {
         $this->filesystem = $filesystem;
-        $this->filesystem->createDir($this->folder);
     }
 
     /**
@@ -52,7 +74,7 @@ class FilesystemCachePool extends AbstractCachePool
      */
     public function setFolder($folder)
     {
-        $this->folder = $folder;
+        $this->folder = trim($folder, '/');
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      |no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

### Description
I added some getters and setters for $folder and $filesystem, so I can access them from my class (extends FilesystemCachePool), as they are declared private.


### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
