### PR TITLE
Fix PrefixedCachePool to strip off the prefix when getting multiple keys.

### DIFF
--- a/src/Prefixed/Changelog.md
+++ b/src/Prefixed/Changelog.md
@@ -4,6 +4,8 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+* Fixed PrefixedCachePool: getItems() would expose the prefix in the array keys it returned.
+
 ## 1.1.0
 
 ### Added

--- a/src/Prefixed/PrefixedCachePool.php
+++ b/src/Prefixed/PrefixedCachePool.php
@@ -55,7 +55,26 @@ class PrefixedCachePool implements CacheItemPoolInterface
     {
         $this->prefixValues($keys);
 
-        return $this->cachePool->getItems($keys);
+        /** @type CacheItemInterface[] $items */
+        $items = $this->cachePool->getItems($keys);
+
+        return iterator_to_array($this->yieldWithoutPrefix($items));
+    }
+
+    /**
+     * @param CacheItemInterface[] $items
+     *
+     * @return \Generator|null
+     */
+    protected function yieldWithoutPrefix($items)
+    {
+        $prefixLength = strlen($this->prefix);
+        foreach ($items as $key => $val) {
+            if (strpos($key, $this->prefix) === 0) {
+                $key = substr($key, $prefixLength);
+            }
+            yield str_replace($this->prefix, '', $key) => $val;
+        }
     }
 
     /**

--- a/src/Prefixed/Tests/PrefixedCachePoolTest.php
+++ b/src/Prefixed/Tests/PrefixedCachePoolTest.php
@@ -49,13 +49,16 @@ class PrefixedCachePoolTest extends TestCase
         $prefix      = 'ns';
         $key0        = 'key0';
         $key1        = 'key1';
-        $returnValue = true;
+        // Value returned by the mocked cache pool wrapped by the PrefixedCachePool
+        $mockValue   = ['nskey0' => true, 'nskey1' => true];
+        // Value expected to be returned by the PrefixedCachePool.
+        $expectedValue = ['key0' => true, 'key1' => true];
 
         $stub = $this->getCacheStub();
-        $stub->expects($this->once())->method('getItems')->with([$prefix.$key0, $prefix.$key1])->willReturn($returnValue);
+        $stub->expects($this->once())->method('getItems')->with([$prefix.$key0, $prefix.$key1])->willReturn($mockValue);
 
         $pool = new PrefixedCachePool($stub, $prefix);
-        $this->assertEquals($returnValue, $pool->getItems([$key0, $key1]));
+        $this->assertEquals($expectedValue, $pool->getItems([$key0, $key1]));
     }
 
     public function testHasItem()


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes - with fix to incorrect existing test
| Fixed tickets | https://github.com/php-cache/issues/issues/139
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

### Description
The PrefixedCachePool modified the array keys of the items being requested. This caused consumers to be unable to check if the items they requested were successfully retrieved from the cache.

### TODO
* [x] Add tests
* [x] Add documentation
* [x] Updated Changelog.md
