### PR TITLE
Fix NamespacedCachePool to strip off the prefix when getting multiple keys

### DIFF
--- a/src/Namespaced/Changelog.md
+++ b/src/Namespaced/Changelog.md
@@ -4,6 +4,8 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+* Fixed namespace prefix being exposed to consumers of the pool when getting multiple items.
+
 ## 1.0.0
 
 ### Added

--- a/src/Namespaced/NamespacedCachePool.php
+++ b/src/Namespaced/NamespacedCachePool.php
@@ -45,7 +45,7 @@ class NamespacedCachePool implements HierarchicalPoolInterface
     /**
      * Add namespace prefix on the key.
      *
-     * @param array $keys
+     * @param string $key
      */
     private function prefixValue(&$key)
     {

--- a/src/Namespaced/Tests/NamespacedCachePoolTest.php
+++ b/src/Namespaced/Tests/NamespacedCachePoolTest.php
@@ -50,13 +50,19 @@ class NamespacedCachePoolTest extends TestCase
         $namespace   = 'ns';
         $key0        = 'key0';
         $key1        = 'key1';
-        $returnValue = true;
+        // Value returned by the mocked cache pool wrapped by the NamespacedCachePool
+        $mockedValue = ['|ns|key0' => true, '|ns|key1' => true];
+        // Value expected to be returned by the NamespacedCachePool
+        $expectedValue = ['key0' => true, 'key1' => true];
 
         $stub = $this->getHierarchyCacheStub();
-        $stub->expects($this->once())->method('getItems')->with(['|'.$namespace.'|'.$key0, '|'.$namespace.'|'.$key1])->willReturn($returnValue);
+        $stub->expects($this->once())
+            ->method('getItems')
+            ->with(['|'.$namespace.'|'.$key0, '|'.$namespace.'|'.$key1])
+            ->willReturn($mockedValue);
 
         $pool = new NamespacedCachePool($stub, $namespace);
-        $this->assertEquals($returnValue, $pool->getItems([$key0, $key1]));
+        $this->assertEquals($expectedValue, $pool->getItems([$key0, $key1]));
     }
 
     public function testHasItem()


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes, with fix of incorrect test.
| Fixed tickets | https://github.com/php-cache/issues/issues/139
| License       | MIT

### Description

Fixed namespace prefix being exposed to consumers of the pool when getting multiple items.

### TODO
* [x] Add tests
* [ ] Add documentation
* [x] Updated Changelog.md
