### PR TITLE
Switch Redis to use Sets instead of Lists

### DIFF
--- a/src/Adapter/Redis/RedisCachePool.php
+++ b/src/Adapter/Redis/RedisCachePool.php
@@ -145,7 +145,7 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
      */
     protected function appendListItem($name, $value)
     {
-        $this->cache->lPush($name, $value);
+        $this->cache->sAdd($name, $value);
     }
 
     /**
@@ -153,7 +153,7 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
      */
     protected function getList($name)
     {
-        return $this->cache->lRange($name, 0, -1);
+        return $this->cache->sMembers($name);
     }
 
     /**
@@ -169,6 +169,6 @@ class RedisCachePool extends AbstractCachePool implements HierarchicalPoolInterf
      */
     protected function removeListItem($name, $key)
     {
-        return $this->cache->lrem($name, $key, 0);
+        return $this->cache->sRem($name, $key, 0);
     }
 }


### PR DESCRIPTION
The current Redis cache implementation uses lists for the tags.  However as lists allow duplicates this results in duplicate records when an expired key is re added with the same tag.  Sets work the same as lists except the enforce uniqueness of values and are not sorted.