### PR TITLE
APCU: use ttl of 0 when passed null

### DIFF
--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -84,7 +84,7 @@ class ApcuCachePool extends AbstractCachePool
         if ($ttl < 0) {
             return false;
         }
-        
+
         if ($ttl === null) {
             $ttl = 0;
         }

--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -84,6 +84,10 @@ class ApcuCachePool extends AbstractCachePool
         if ($ttl < 0) {
             return false;
         }
+        
+        if ($ttl === null) {
+            $ttl = 0;
+        }
 
         return apcu_store($item->getKey(), serialize([$item->get(), $item->getTags(), $item->getExpirationTimestamp()]), $ttl);
     }


### PR DESCRIPTION
Under PHP 8.1 alpha builds, a deprecation warning about invalid `$ttl` is emitted when `null` is passed:

```
PHP Deprecated:  apcu_store(): Passing null to parameter #3 ($ttl) of type int is deprecated in /var/www/html/vendor/cache/apcu-adapter/ApcuCachePool.php on line 88
```

This change fixes the issue.

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
| License       | MIT
| Doc PR        | reference to the documentation PR, if any