### PR TITLE
APCu - Remove not needed serialize / unserialize

### DIFF
--- a/src/Adapter/Apcu/ApcuCachePool.php
+++ b/src/Adapter/Apcu/ApcuCachePool.php
@@ -49,7 +49,7 @@ class ApcuCachePool extends AbstractCachePool
         if (!$success) {
             return [false, null, [], null];
         }
-        list($data, $tags, $timestamp) = unserialize($cacheData);
+        list($data, $tags, $timestamp) = $cacheData;
 
         return [$success, $data, $tags, $timestamp];
     }
@@ -85,7 +85,7 @@ class ApcuCachePool extends AbstractCachePool
             return false;
         }
 
-        return apcu_store($item->getKey(), serialize([$item->get(), $item->getTags(), $item->getExpirationTimestamp()]), $ttl);
+        return apcu_store($item->getKey(), [$item->get(), $item->getTags(), $item->getExpirationTimestamp()], $ttl);
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | `composer test` -> `Command "test" is not defined` -> couldn't run
| Fixed tickets | -
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

### Description

As https://www.php.net/manual/en/function.apcu-store.php tells, `apcu_store()` accepts `mixed` as variable type. APCu module performs serialization / unserialization internally. The serializer to use is configured as APCu module runtime configuration: https://www.php.net/manual/en/apcu.configuration.php#ini.apcu.serializer

One alternative serializer is https://www.php.net/manual/en/intro.igbinary.php, which uses more efficient encoding for serialization than the standard PHP text serialization.

If the cache adapter serializes `apc_store()` values, there is no benefit in using `igbinary` serializer, because the input is always text.

As a summary: There is no need to serialize / unserialize input / output from cache. It adds the overhead of second serialize and deserialize calls, and cripples optimisations from improved serialzers.

Personally I have used APCu functionality without serialization for years in production environment without any issues.

This change shouldn't need any additional tests. I assume the store / fetch correctness is tested in existing tests.

### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
