### PR TITLE
Allow psr/cache ^1.0 || ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "doctrine/cache": "^1.3",
         "league/flysystem": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Adapter/Apc/composer.json
+++ b/src/Adapter/Apc/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Apcu/composer.json
+++ b/src/Adapter/Apcu/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Chain/composer.json
+++ b/src/Adapter/Chain/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "cache/tag-interop": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {

--- a/src/Adapter/Common/composer.json
+++ b/src/Adapter/Common/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/tag-interop": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Adapter/Doctrine/composer.json
+++ b/src/Adapter/Doctrine/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "doctrine/cache": "^1.6",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Filesystem/composer.json
+++ b/src/Adapter/Filesystem/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "league/flysystem": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Illuminate/composer.json
+++ b/src/Adapter/Illuminate/composer.json
@@ -33,7 +33,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "illuminate/cache": "^5.4 || ^5.5 || ^5.6",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Memcached/composer.json
+++ b/src/Adapter/Memcached/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/MongoDB/composer.json
+++ b/src/Adapter/MongoDB/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.1",
         "mongodb/mongodb": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/PHPArray/composer.json
+++ b/src/Adapter/PHPArray/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Predis/composer.json
+++ b/src/Adapter/Predis/composer.json
@@ -28,7 +28,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "predis/predis": "^1.1",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Redis/composer.json
+++ b/src/Adapter/Redis/composer.json
@@ -27,7 +27,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Adapter/Void/composer.json
+++ b/src/Adapter/Void/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Bridge/SimpleCache/composer.json
+++ b/src/Bridge/SimpleCache/composer.json
@@ -19,7 +19,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/Encryption/composer.json
+++ b/src/Encryption/composer.json
@@ -32,7 +32,7 @@
         "cache/adapter-common": "^1.1",
         "cache/tag-interop": "^1.0",
         "defuse/php-encryption": "^2.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0 || ^2.0"
     },
     "require-dev": {
         "cache/filesystem-adapter": "^1.0",

--- a/src/Hierarchy/composer.json
+++ b/src/Hierarchy/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.21"

--- a/src/Namespaced/composer.json
+++ b/src/Namespaced/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0 || ^2.0"
     },
     "require-dev": {
         "cache/memcached-adapter": "^1.0",

--- a/src/Prefixed/composer.json
+++ b/src/Prefixed/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/hierarchical-cache": "^0.4",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/SessionHandler/composer.json
+++ b/src/SessionHandler/composer.json
@@ -28,7 +28,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "symfony/polyfill-php70": "^1.6"
     },
     "require-dev": {

--- a/src/Taggable/composer.json
+++ b/src/Taggable/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
         "cache/tag-interop": "^1.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0 || ^2.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.16",

--- a/src/Util/composer.json
+++ b/src/Util/composer.json
@@ -25,7 +25,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": "^5.6 || ^7.0 || ^8.0",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0 || ^2.0"
     },
     "require-dev": {
         "cache/array-adapter": "^1.0",


### PR DESCRIPTION
All packages now allow v1 and v2.

Followup from https://github.com/php-cache/cache/pull/253