### PR TITLE
added extra check before unserialising

### DIFF
--- a/src/Adapter/Filesystem/FilesystemCachePool.php
+++ b/src/Adapter/Filesystem/FilesystemCachePool.php
@@ -159,7 +159,13 @@ class FilesystemCachePool extends AbstractCachePool
             $this->filesystem->write($file, serialize([]));
         }
 
-        return unserialize($this->filesystem->read($file));
+        $data = $this->filesystem->read($file);
+        if ($data === false) {
+            $this->filesystem->update($file, serialize([]));
+            $data = [];
+        }
+
+        return unserialize($data);
     }
 
     /**


### PR DESCRIPTION
added extra check before unserialising, when file exists but is corrupted fallback to default before like when the file isn't present and overwrite the corrupt file.

| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | https://github.com/php-cache/issues/issues/153
| License       | MIT
| Doc PR        | reference to the documentation PR, if any



