### PR TITLE
Add return type annotation to future proof PSR-6 compatibility

### DIFF
--- a/src/Adapter/Common/AbstractCachePool.php
+++ b/src/Adapter/Common/AbstractCachePool.php
@@ -154,6 +154,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function hasItem($key)
     {
@@ -166,6 +168,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function clear()
     {
@@ -181,6 +185,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function deleteItem($key)
     {
@@ -193,6 +199,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function deleteItems(array $keys)
     {
@@ -217,6 +225,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function save(CacheItemInterface $item)
     {
@@ -245,6 +255,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function saveDeferred(CacheItemInterface $item)
     {
@@ -255,6 +267,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function commit()
     {
@@ -423,6 +437,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($key, $default = null)
     {
@@ -436,6 +452,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function set($key, $value, $ttl = null)
     {
@@ -448,6 +466,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function delete($key)
     {
@@ -456,6 +476,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return iterable
      */
     public function getMultiple($keys, $default = null)
     {
@@ -494,6 +516,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function setMultiple($values, $ttl = null)
     {
@@ -533,6 +557,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function deleteMultiple($keys)
     {
@@ -551,6 +577,8 @@ abstract class AbstractCachePool implements PhpCachePool, LoggerAwareInterface, 
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function has($key)
     {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

### Description

While working on my [open source project](https://phansible.com) I noticed that my build was breaking due to warning raised by my tests. I have a transient dependency to this package and it's raising multiple potential, future incompatibility warning in the form of:
```
1x: Method "Psr\Cache\CacheItemPoolInterface::methodName()" might add "type" as a native return type declaration in the future. Do the same in implementation "Cache\Adapter\Common\AbstractCachePool" now to avoid errors or add an explicit @return annotation to suppress this message.
```
I decided to add the annotation for now rather than change the implementation and leave that for a future date.

UPDATE: I think this changes is still a nice to have, but it also turns out that the warning was raised by `symfony/phpunit-bridge`. Credits to @mareg and @ciaranmcnulty for the additional input.

PS: It would be really nice if you could also add the hacktoberfest-accepted label to this PR. I hope it helps. Thank you.
