### PR TITLE
Allow common adapters to use later versions of psr/simple-cache

### DIFF
--- a/src/Adapter/Apc/composer.json
+++ b/src/Adapter/Apc/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Apcu/composer.json
+++ b/src/Adapter/Apcu/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Common/composer.json
+++ b/src/Adapter/Common/composer.json
@@ -26,7 +26,7 @@
         "cache/tag-interop": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Doctrine/composer.json
+++ b/src/Adapter/Doctrine/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.0",
         "doctrine/cache": "^1.6",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Filesystem/composer.json
+++ b/src/Adapter/Filesystem/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.0",
         "league/flysystem": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Illuminate/composer.json
+++ b/src/Adapter/Illuminate/composer.json
@@ -34,7 +34,7 @@
         "cache/hierarchical-cache": "^1.0",
         "illuminate/cache": "^5.4 || ^5.5 || ^5.6",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -26,7 +26,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Memcached/composer.json
+++ b/src/Adapter/Memcached/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/MongoDB/composer.json
+++ b/src/Adapter/MongoDB/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.1",
         "mongodb/mongodb": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/PHPArray/composer.json
+++ b/src/Adapter/PHPArray/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Predis/composer.json
+++ b/src/Adapter/Predis/composer.json
@@ -29,7 +29,7 @@
         "cache/hierarchical-cache": "^1.0",
         "predis/predis": "^1.1",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Redis/composer.json
+++ b/src/Adapter/Redis/composer.json
@@ -28,7 +28,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Void/composer.json
+++ b/src/Adapter/Void/composer.json
@@ -27,7 +27,7 @@
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | ...
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description
This PR allows the common adapters to use later versions of `psr/simple-cache`.


### TODO
* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
