### PR TITLE
Remove indirect dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.7.0
+        uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           coverage: none
           tools: composer-normalize
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,17 @@ jobs:
 
     services:
       redis:
-        image: redis:6.0.0
+        image: redis:7.0
         ports:
           - 6379:6379
       redis-cluster:
-        image: grokzen/redis-cluster:5.0.4
+        image: grokzen/redis-cluster:6.2.10
         ports:
           - 7000:7000
           - 7001:7001
           - 7002:7002
         env:
-          STANDALONE: 1
+          IP: 0.0.0.0
       memcached:
         image: memcached:1.6.5
         ports:
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.7.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/composer.json
+++ b/composer.json
@@ -106,5 +106,10 @@
         "branch-alias": {
             "dev-master": "1.1-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "cache/integration-tests": "^0.17",
         "defuse/php-encryption": "^2.0",
-        "illuminate/cache": "^5.4 || ^5.5 || ^5.6",
+        "illuminate/cache": "^5.4",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.5.20 || ^9.5.10",
         "predis/predis": "^1.1",
@@ -105,11 +105,6 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"
-        }
-    },
-    "config": {
-        "allow-plugins": {
-            "kylekatarnls/update-helper": true
         }
     }
 }

--- a/src/Adapter/Apc/composer.json
+++ b/src/Adapter/Apc/composer.json
@@ -23,9 +23,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.4",
-        "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/adapter-common": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Apcu/composer.json
+++ b/src/Adapter/Apcu/composer.json
@@ -23,9 +23,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.4",
-        "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/adapter-common": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Doctrine/composer.json
+++ b/src/Adapter/Doctrine/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "doctrine/cache": "^1.6",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "doctrine/cache": "^1.6"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Filesystem/composer.json
+++ b/src/Adapter/Filesystem/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "league/flysystem": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "league/flysystem": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Illuminate/composer.json
+++ b/src/Adapter/Illuminate/composer.json
@@ -32,7 +32,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "illuminate/cache": "^5.4 || ^5.5 || ^5.6",
+        "illuminate/cache": "^5.4",
         "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
@@ -54,6 +54,11 @@
         "exclude-from-classmap": [
             "/Tests/"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "kylekatarnls/update-helper": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Adapter/Illuminate/composer.json
+++ b/src/Adapter/Illuminate/composer.json
@@ -32,9 +32,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "illuminate/cache": "^5.4",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "illuminate/cache": "^5.4"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Memcache/composer.json
+++ b/src/Adapter/Memcache/composer.json
@@ -24,9 +24,7 @@
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
         "php": ">=7.4",
-        "cache/adapter-common": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/adapter-common": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Memcached/composer.json
+++ b/src/Adapter/Memcached/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/hierarchical-cache": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/MongoDB/composer.json
+++ b/src/Adapter/MongoDB/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.1",
-        "mongodb/mongodb": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "mongodb/mongodb": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/PHPArray/composer.json
+++ b/src/Adapter/PHPArray/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/hierarchical-cache": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Predis/Changelog.md
+++ b/src/Adapter/Predis/Changelog.md
@@ -4,6 +4,9 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+* Update predis/predis: ^2.0
+* Fixed unserialized(null) deprecation
+
 ## 1.2.0
 
 * Support for PHP 8.1

--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -42,7 +42,7 @@ class PredisCachePool extends AbstractCachePool implements HierarchicalPoolInter
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
+        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)) ?? '')) {
             return [false, null, [], null];
         }
 

--- a/src/Adapter/Predis/composer.json
+++ b/src/Adapter/Predis/composer.json
@@ -27,7 +27,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "predis/predis": "^1.1",
+        "predis/predis": "^2.0",
         "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Adapter/Predis/composer.json
+++ b/src/Adapter/Predis/composer.json
@@ -27,9 +27,7 @@
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
         "cache/hierarchical-cache": "^1.0",
-        "predis/predis": "^2.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "predis/predis": "^2.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Redis/composer.json
+++ b/src/Adapter/Redis/composer.json
@@ -26,9 +26,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/hierarchical-cache": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",

--- a/src/Adapter/Void/composer.json
+++ b/src/Adapter/Void/composer.json
@@ -25,9 +25,7 @@
     "require": {
         "php": ">=7.4",
         "cache/adapter-common": "^1.0",
-        "cache/hierarchical-cache": "^1.0",
-        "psr/cache": "^1.0 || ^2.0",
-        "psr/simple-cache": "^1.0"
+        "cache/hierarchical-cache": "^1.0"
     },
     "require-dev": {
         "cache/integration-tests": "^0.17",


### PR DESCRIPTION
| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

### Description

Most of the adapters don't require `psr/cache` and `psr/simple-cache`, at least not directly, so I think it's safe to remove these dependencies from `composer.json`.