### PR TITLE
Guarding against null values before unserializing

### DIFF
--- a/src/Adapter/Predis/PredisCachePool.php
+++ b/src/Adapter/Predis/PredisCachePool.php
@@ -42,11 +42,13 @@ class PredisCachePool extends AbstractCachePool implements HierarchicalPoolInter
      */
     protected function fetchObjectFromCache($key)
     {
-        if (false === $result = unserialize($this->cache->get($this->getHierarchyKey($key)))) {
+        $result = $this->cache->get($this->getHierarchyKey($key));
+
+        if (false === $result || null === $result) {
             return [false, null, [], null];
         }
 
-        return $result;
+        return unserialize($result);
     }
 
     /**


### PR DESCRIPTION

| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

### Description

 Guarding against null values before calling `unserialize`. This addresses `E_DEPRECATED` notices in PHP 8.2 when unserializing as the function signature now only accepts string values.

### TODO

* [ ] Add tests
* [ ] Add documentation
* [ ] Updated Changelog.md
